### PR TITLE
Changed transaction extra and fixed hash target tests

### DIFF
--- a/src/CryptoNoteCore/TransactionExtra.h
+++ b/src/CryptoNoteCore/TransactionExtra.h
@@ -10,8 +10,8 @@
 
 #include <CryptoNote.h>
 
-#define TX_EXTRA_PADDING_MAX_COUNT          15
-#define TX_EXTRA_NONCE_MAX_COUNT            100
+#define TX_EXTRA_PADDING_MAX_COUNT          60
+#define TX_EXTRA_NONCE_MAX_COUNT            60
 
 #define TX_EXTRA_TAG_PADDING                0x00
 #define TX_EXTRA_TAG_PUBKEY                 0x01

--- a/tests/HashTarget.cpp
+++ b/tests/HashTarget.cpp
@@ -23,7 +23,7 @@ int main(int argc, char *argv[]) {
       }
       if (b > 0) {
         memset(&h, 0, sizeof(Crypto::Hash));
-        ((char *) &h)[31] = b;
+        ((char *) &h)[0] = b;
         if (check_hash(h, diff) != (diff <= 255 / b)) {
           return 1;
         }
@@ -31,7 +31,7 @@ int main(int argc, char *argv[]) {
     }
     if (diff < numeric_limits<uint64_t>::max() / 256) {
       uint64_t val = 0;
-      for (int i = 31; i >= 0; i--) {
+      for (int i = 0; i < 32; i++) {
         val = val * 256 + 255;
         ((char *) &h)[i] = static_cast<char>(val / diff);
         val %= diff;


### PR DESCRIPTION
Changed transaction extra padding and transaction extra nonce to have the same maximum size because a previous tests checks to make sure they are equal.
Fixed hash target test so that it is working with big endian hashes rather than little endian hashes