### PR TITLE
Hard Fork 1 - Removed Adaptive Block Sizes to Speed Up Blockchain Sync

### DIFF
--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -28,7 +28,7 @@ static_assert(EMISSION_SPEED_FACTOR <= 8 * sizeof(uint64_t), "Bad EMISSION_SPEED
 const size_t   CRYPTONOTE_REWARD_BLOCKS_WINDOW               = 60 * 24 * 60 * 60 / DIFFICULTY_TARGET; // number of blocks produced in 60 days
 const size_t   CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE     = 200 * 1024; //size of block (bytes) after which reward for block calculated using block size, 200 kb
 const size_t   CRYPTONOTE_COINBASE_BLOB_RESERVED_SIZE        = 600;
-const size_t   CRYPTONOTE_DISPLAY_DECIMAL_POINT              = 9; // number of digits after decimal poin
+const size_t   CRYPTONOTE_DISPLAY_DECIMAL_POINT              = 9; // number of digits after decimal point
 const uint64_t MINIMUM_FEE                                   = 0; // free transactions
 const uint64_t DEFAULT_DUST_THRESHOLD                        = MINIMUM_FEE;
 const uint64_t MAX_MIXIN                                     = 3;
@@ -57,6 +57,8 @@ const char     P2P_NET_DATA_FILENAME[]                       = "p2pstate.bin";
 const char     CRYPTONOTE_BLOCKCHAIN_INDEXES_FILENAME[]      = "blockchainindexes.dat";
 const char     MINER_CONFIG_FILE_NAME[]                      = "miner_conf.json";
 
+const uint64_t HARD_FORK_HEIGHT_1                            = 230500;
+
 } // end namespace parameters
 
 const char     CRYPTONOTE_NAME[]                             = "cash2";
@@ -83,8 +85,8 @@ const char     P2P_STAT_TRUSTED_PUB_KEY[]                    = "";
 
 //seed nodes
 const std::initializer_list<const char*> SEED_NODES = {
-  "52.200.158.167:12275",
-  "52.203.127.98:12275",
+  "seed1.cash2.org:12275",
+  "seed2.cash2.org:12275",
 };
 
 struct CheckpointData {

--- a/src/CryptoNoteCore/Core.h
+++ b/src/CryptoNoteCore/Core.h
@@ -45,7 +45,7 @@ namespace CryptoNote {
 
     //-------------------- IMinerHandler -----------------------
     virtual bool handle_block_found(Block& b) override;
-    virtual bool get_block_template(Block& b, const AccountPublicAddress& adr, difficulty_type& diffic, uint32_t& height, const BinaryArray& ex_nonce) override;
+    virtual bool get_block_template(Block& b, const AccountPublicAddress& adr, difficulty_type& diffic, uint32_t& blockchainHeight, const BinaryArray& ex_nonce) override;
 
     bool addObserver(ICoreObserver* observer) override;
     bool removeObserver(ICoreObserver* observer) override;
@@ -62,7 +62,9 @@ namespace CryptoNote {
     virtual bool getBackwardBlocksSizes(uint32_t fromHeight, std::vector<size_t>& sizes, size_t count) override;
     virtual bool getBlockSize(const Crypto::Hash& hash, size_t& size) override;
     virtual bool getAlreadyGeneratedCoins(const Crypto::Hash& hash, uint64_t& generatedCoins) override;
-    virtual bool getBlockReward(size_t medianSize, size_t currentBlockSize, uint64_t alreadyGeneratedCoins, uint64_t fee,
+    virtual bool getBlockReward1(size_t medianSize, size_t currentBlockSize, uint64_t alreadyGeneratedCoins, uint64_t fee,
+                                uint64_t& reward, int64_t& emissionChange) override;
+    virtual bool getBlockReward2(uint32_t blockHeight, size_t currentBlockSize, uint64_t alreadyGeneratedCoins, uint64_t fee,
                                 uint64_t& reward, int64_t& emissionChange) override;
     virtual bool scanOutputkeysForIndexes(const KeyInput& txInToKey, std::list<std::pair<Crypto::Hash, size_t>>& outputReferences) override;
     virtual bool getBlockDifficulty(uint32_t height, difficulty_type& difficulty) override;
@@ -126,7 +128,7 @@ namespace CryptoNote {
     void print_blockchain(uint32_t start_index, uint32_t end_index);
     void print_blockchain_index();
     std::string print_pool(bool short_format);
-	std::list<CryptoNote::tx_memory_pool::TransactionDetails> getMemoryPool() const;
+    std::list<CryptoNote::tx_memory_pool::TransactionDetails> getMemoryPool() const;
     void print_blockchain_outs(const std::string& file);
     virtual bool getPoolChanges(const Crypto::Hash& tailBlockId, const std::vector<Crypto::Hash>& knownTxsIds,
                                  std::vector<Transaction>& addedTxs, std::vector<Crypto::Hash>& deletedTxsIds) override;

--- a/src/CryptoNoteCore/Currency.h
+++ b/src/CryptoNoteCore/Currency.h
@@ -76,13 +76,15 @@ public:
   const Block& genesisBlock() const { return m_genesisBlock; }
   const Crypto::Hash& genesisBlockHash() const { return m_genesisBlockHash; }
 
-  bool getBlockReward(size_t medianSize, size_t currentBlockSize, uint64_t alreadyGeneratedCoins, uint64_t fee,
-    uint64_t& reward, int64_t& emissionChange) const;
+  bool getBlockReward1(size_t medianSize, size_t currentBlockSize, uint64_t alreadyGeneratedCoins, uint64_t fee, uint64_t& reward, int64_t& emissionChange) const;
+  bool getBlockReward2(uint32_t blockHeight, size_t currentBlockSize, uint64_t alreadyGeneratedCoins, uint64_t fee, uint64_t& reward, int64_t& emissionChange) const;
   size_t maxBlockCumulativeSize(uint64_t height) const;
 
-  bool constructMinerTx(uint32_t height, size_t medianSize, uint64_t alreadyGeneratedCoins, size_t currentBlockSize,
+  bool constructMinerTx1(uint32_t height, size_t medianSize, uint64_t alreadyGeneratedCoins, size_t currentBlockSize,
     uint64_t fee, const AccountPublicAddress& minerAddress, Transaction& tx,
     const BinaryArray& extraNonce = BinaryArray(), size_t maxOuts = 1) const;
+
+  bool constructMinerTx2(uint32_t height, uint64_t alreadyGeneratedCoins, size_t currentBlockSize, uint64_t fee, const AccountPublicAddress& minerAddress, Transaction& tx, const BinaryArray& extraNonce, size_t maxOuts) const;
 
   bool isFusionTransaction(const Transaction& transaction) const;
   bool isFusionTransaction(const Transaction& transaction, size_t size) const;
@@ -161,6 +163,8 @@ private:
   std::string m_txPoolFileName;
   std::string m_blockchainIndexesFileName;
 
+  uint64_t m_hardForkHeight1;
+
   static const std::vector<uint64_t> PRETTY_AMOUNTS;
 
   bool m_testnet;
@@ -234,6 +238,8 @@ public:
   CurrencyBuilder& txPoolFileName(const std::string& val) { m_currency.m_txPoolFileName = val; return *this; }
   CurrencyBuilder& blockchainIndexesFileName(const std::string& val) { m_currency.m_blockchainIndexesFileName = val; return *this; }
   
+  CurrencyBuilder& hardForkHeight1(uint64_t val) { m_currency.m_hardForkHeight1 = val; return *this; }
+
   CurrencyBuilder& testnet(bool val) { m_currency.m_testnet = val; return *this; }
 
 private:

--- a/src/CryptoNoteCore/ICore.h
+++ b/src/CryptoNoteCore/ICore.h
@@ -85,7 +85,9 @@ public:
   virtual bool getBackwardBlocksSizes(uint32_t fromHeight, std::vector<size_t>& sizes, size_t count) = 0;
   virtual bool getBlockSize(const Crypto::Hash& hash, size_t& size) = 0;
   virtual bool getAlreadyGeneratedCoins(const Crypto::Hash& hash, uint64_t& generatedCoins) = 0;
-  virtual bool getBlockReward(size_t medianSize, size_t currentBlockSize, uint64_t alreadyGeneratedCoins, uint64_t fee,
+  virtual bool getBlockReward1(size_t medianSize, size_t currentBlockSize, uint64_t alreadyGeneratedCoins, uint64_t fee,
+                              uint64_t& reward, int64_t& emissionChange) = 0;
+  virtual bool getBlockReward2(uint32_t blockHeight, size_t currentBlockSize, uint64_t alreadyGeneratedCoins, uint64_t fee,
                               uint64_t& reward, int64_t& emissionChange) = 0;
   virtual bool scanOutputkeysForIndexes(const KeyInput& txInToKey, std::list<std::pair<Crypto::Hash, size_t>>& outputReferences) = 0;
   virtual bool getBlockDifficulty(uint32_t height, difficulty_type& difficulty) = 0;

--- a/src/CryptoNoteCore/IMinerHandler.h
+++ b/src/CryptoNoteCore/IMinerHandler.h
@@ -11,7 +11,7 @@
 namespace CryptoNote {
   struct IMinerHandler {
     virtual bool handle_block_found(Block& b) = 0;
-    virtual bool get_block_template(Block& b, const AccountPublicAddress& adr, difficulty_type& diffic, uint32_t& height, const BinaryArray& ex_nonce) = 0;
+    virtual bool get_block_template(Block& b, const AccountPublicAddress& adr, difficulty_type& diffic, uint32_t& blockchainHeight, const BinaryArray& ex_nonce) = 0;
 
   protected:
     ~IMinerHandler(){};

--- a/src/CryptoNoteCore/TransactionPool.h
+++ b/src/CryptoNoteCore/TransactionPool.h
@@ -97,7 +97,8 @@ namespace CryptoNote {
     void unlock() const;
     std::unique_lock<std::recursive_mutex> obtainGuard() const;
 
-    bool fill_block_template(Block &bl, size_t median_size, size_t maxCumulativeSize, uint64_t already_generated_coins, size_t &total_size, uint64_t &fee);
+    bool fill_block_template1(Block &bl, size_t median_size, size_t maxCumulativeSize, uint64_t already_generated_coins, size_t &total_size, uint64_t &fee);
+    bool fill_block_template2(Block &bl, size_t maxCumulativeSize, uint64_t already_generated_coins, size_t &total_size, uint64_t &fee);
 
     void get_transactions(std::list<Transaction>& txs) const;
     void get_difference(const std::vector<Crypto::Hash>& known_tx_ids, std::vector<Crypto::Hash>& new_tx_ids, std::vector<Crypto::Hash>& deleted_tx_ids) const;

--- a/tests/Basic/BlockReward/main.cpp
+++ b/tests/Basic/BlockReward/main.cpp
@@ -51,7 +51,7 @@ TEST_F(TestCurrency1, 1)
   int64_t emissionChange = 0;
   uint64_t blockReward = 0;
 
-  bool blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
+  bool blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
                                             transactionFees, blockReward, emissionChange);
   ASSERT_FALSE(blockTooBig);
   ASSERT_EQ(expectedBlockReward, blockReward);
@@ -69,7 +69,7 @@ TEST_F(TestCurrency1, 2)
   int64_t emissionChange = 0;
   uint64_t blockReward = 0;
 
-  bool blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
+  bool blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
                                             transactionFees, blockReward, emissionChange);
   ASSERT_FALSE(blockTooBig);
   ASSERT_EQ(expectedBlockReward, blockReward);
@@ -87,7 +87,7 @@ TEST_F(TestCurrency1, 3)
   int64_t emissionChange = 0;
   uint64_t blockReward = 0;
 
-  bool blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
+  bool blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
                                             transactionFees, blockReward, emissionChange);
   ASSERT_FALSE(blockTooBig);
   ASSERT_EQ(expectedBlockReward, blockReward);
@@ -105,7 +105,7 @@ TEST_F(TestCurrency1, 4)
   int64_t emissionChange = 0;
   uint64_t blockReward = 0;
 
-  bool blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
+  bool blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
                                             transactionFees, blockReward, emissionChange);
   ASSERT_FALSE(blockTooBig);
   ASSERT_EQ(expectedBlockReward, blockReward);
@@ -123,7 +123,7 @@ TEST_F(TestCurrency1, 5)
   int64_t emissionChange = 0;
   uint64_t blockReward = 0;
 
-  bool blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
+  bool blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
                                             transactionFees, blockReward, emissionChange);
   ASSERT_FALSE(blockTooBig);
   ASSERT_EQ(expectedBlockReward, blockReward);
@@ -141,7 +141,7 @@ TEST_F(TestCurrency1, 6)
   int64_t emissionChange = 0;
   uint64_t blockReward = 0;
 
-  bool blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
+  bool blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
                                             transactionFees, blockReward, emissionChange);
   ASSERT_FALSE(blockTooBig);
   ASSERT_EQ(expectedBlockReward, blockReward);
@@ -159,7 +159,7 @@ TEST_F(TestCurrency1, 7)
   int64_t emissionChange = 0;
   uint64_t blockReward = 0;
 
-  bool blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
+  bool blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
                                             transactionFees, blockReward, emissionChange);
   ASSERT_FALSE(blockTooBig);
   ASSERT_EQ(expectedBlockReward, blockReward);
@@ -177,7 +177,7 @@ TEST_F(TestCurrency1, 8)
   int64_t emissionChange = 0;
   uint64_t blockReward = 0;
 
-  bool blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
+  bool blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
                                             transactionFees, blockReward, emissionChange);
   ASSERT_FALSE(blockTooBig);
   ASSERT_EQ(expectedBlockReward, blockReward);
@@ -195,7 +195,7 @@ TEST_F(TestCurrency1, 9)
   int64_t emissionChange = 0;
   uint64_t blockReward = 0;
 
-  bool blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
+  bool blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
                                             transactionFees, blockReward, emissionChange);
   ASSERT_FALSE(blockTooBig);
   ASSERT_EQ(expectedBlockReward, blockReward);
@@ -213,7 +213,7 @@ TEST_F(TestCurrency1, 10)
   int64_t emissionChange = 0;
   uint64_t blockReward = 0;
 
-  bool blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
+  bool blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
                                             transactionFees, blockReward, emissionChange);
   ASSERT_FALSE(blockTooBig);
   ASSERT_EQ(expectedBlockReward, blockReward);
@@ -238,7 +238,7 @@ TEST_F(TestCurrency1, 11)
   int64_t emissionChange = 0;
   uint64_t blockReward = 0;
 
-  bool blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
+  bool blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
                                             transactionFees, blockReward, emissionChange);
   ASSERT_FALSE(blockTooBig);
   ASSERT_EQ(expectedBlockReward, blockReward);
@@ -263,7 +263,7 @@ TEST_F(TestCurrency1, 12)
   int64_t emissionChange = 0;
   uint64_t blockReward = 0;
 
-  bool blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
+  bool blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
                                             transactionFees, blockReward, emissionChange);
   ASSERT_FALSE(blockTooBig);
   ASSERT_EQ(expectedBlockReward, blockReward);
@@ -288,7 +288,7 @@ TEST_F(TestCurrency1, 13)
   int64_t emissionChange = 0;
   uint64_t blockReward = 0;
 
-  bool blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
+  bool blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
                                             transactionFees, blockReward, emissionChange);
   ASSERT_FALSE(blockTooBig);
   ASSERT_EQ(expectedBlockReward, blockReward);
@@ -313,7 +313,7 @@ TEST_F(TestCurrency1, 14)
   int64_t emissionChange = 0;
   uint64_t blockReward = 0;
 
-  bool blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
+  bool blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
                                             transactionFees, blockReward, emissionChange);
   ASSERT_FALSE(blockTooBig);
   ASSERT_EQ(expectedBlockReward, blockReward);
@@ -338,7 +338,7 @@ TEST_F(TestCurrency1, 15)
   int64_t emissionChange = 0;
   uint64_t blockReward = 0;
 
-  bool blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
+  bool blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
                                             transactionFees, blockReward, emissionChange);
   ASSERT_FALSE(blockTooBig);
   ASSERT_EQ(expectedBlockReward, blockReward);
@@ -363,7 +363,7 @@ TEST_F(TestCurrency1, 16)
   int64_t emissionChange = 0;
   uint64_t blockReward = 0;
 
-  bool blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
+  bool blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
                                             transactionFees, blockReward, emissionChange);
   ASSERT_FALSE(blockTooBig);
   ASSERT_EQ(expectedBlockReward, blockReward);
@@ -381,7 +381,7 @@ TEST_F(TestCurrency1, 17)
   int64_t emissionChange = 0;
   uint64_t blockReward = 0;
 
-  bool blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
+  bool blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
                                             transactionFees, blockReward, emissionChange);
   ASSERT_FALSE(blockTooBig);
   ASSERT_EQ(expectedBlockReward, blockReward);
@@ -399,7 +399,7 @@ TEST_F(TestCurrency1, 18)
   int64_t emissionChange = 0;
   uint64_t blockReward = 0;
 
-  bool blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
+  bool blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
                                             transactionFees, blockReward, emissionChange);
   ASSERT_FALSE(blockTooBig);
   ASSERT_EQ(expectedBlockReward, blockReward);
@@ -439,7 +439,7 @@ TEST_F(TestCurrency2, 1)
   int64_t emissionChange = 0;
   uint64_t blockReward = 0;
 
-  bool blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
+  bool blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
                                                 transactionFees, blockReward, emissionChange);
   ASSERT_FALSE(blockTooBig);
   ASSERT_EQ(blockReward, expectedFirstBlockReward);
@@ -459,7 +459,7 @@ TEST_F(TestCurrency2, 2)
   int64_t emissionChange = 0;
   uint64_t blockReward = 0;
   
-  bool blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
+  bool blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
                                                 transactionFees, blockReward, emissionChange);
   ASSERT_FALSE(blockTooBig);
   ASSERT_EQ(blockReward, expectedFirstBlockReward);
@@ -477,7 +477,7 @@ TEST_F(TestCurrency2, 3)
   int64_t emissionChange = 0;
   uint64_t blockReward = 0;
   
-  bool blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
+  bool blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
                                                 transactionFees, blockReward, emissionChange);
   ASSERT_FALSE(blockTooBig);
   ASSERT_EQ(blockReward, expectedFirstBlockReward);
@@ -496,7 +496,7 @@ TEST_F(TestCurrency2, 4)
   int64_t emissionChange = 0;
   uint64_t blockReward = 0;
   
-  bool blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
+  bool blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
                                                 transactionFees, blockReward, emissionChange);
   ASSERT_FALSE(blockTooBig);
   ASSERT_EQ(blockReward, expectedFirstBlockReward);
@@ -514,7 +514,7 @@ TEST_F(TestCurrency2, 5)
   int64_t emissionChange = 0;
   uint64_t blockReward = 0;
   
-  bool blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
+  bool blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
                                                 transactionFees, blockReward, emissionChange);
   ASSERT_FALSE(blockTooBig);
   ASSERT_EQ(blockReward, expectedFirstBlockReward);
@@ -534,7 +534,7 @@ TEST_F(TestCurrency2, 6)
   int64_t emissionChange = 0;
   uint64_t blockReward = 0;
   
-  bool blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
+  bool blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
                                                 transactionFees, blockReward, emissionChange);
   ASSERT_TRUE(blockTooBig);
   ASSERT_EQ(blockReward, 0);
@@ -553,7 +553,7 @@ TEST_F(TestCurrency2, 7)
   int64_t emissionChange = 0;
   uint64_t blockReward = 0;
   
-  bool blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
+  bool blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
                                                 transactionFees, blockReward, emissionChange);
   ASSERT_FALSE(blockTooBig);
   ASSERT_EQ(expectedFirstBlockReward - 1, blockReward);
@@ -593,7 +593,7 @@ TEST_F(TestCurrency3, 1)
   int64_t emissionChange = 0;
   uint64_t blockReward = 0;
 
-  bool blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
+  bool blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
                                             transactionFees, blockReward, emissionChange);
   ASSERT_FALSE(blockTooBig);
   ASSERT_EQ(blockReward, expectedFirstBlockReward);
@@ -612,7 +612,7 @@ TEST_F(TestCurrency3, 2)
   int64_t emissionChange = 0;
   uint64_t blockReward = 0;
 
-  bool blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
+  bool blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
                                             transactionFees, blockReward, emissionChange);
   ASSERT_FALSE(blockTooBig);
   ASSERT_EQ(blockReward, expectedFirstBlockReward);
@@ -631,7 +631,7 @@ TEST_F(TestCurrency3, 3)
   int64_t emissionChange = 0;
   uint64_t blockReward = 0;
 
-  bool blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
+  bool blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
                                             transactionFees, blockReward, emissionChange);
   ASSERT_FALSE(blockTooBig);
   ASSERT_EQ(blockReward, expectedFirstBlockReward);
@@ -650,7 +650,7 @@ TEST_F(TestCurrency3, 4)
   int64_t emissionChange = 0;
   uint64_t blockReward = 0;
 
-  bool blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
+  bool blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
                                             transactionFees, blockReward, emissionChange);
   ASSERT_FALSE(blockTooBig);
   ASSERT_EQ(expectedFirstBlockReward - 1, blockReward);
@@ -669,7 +669,7 @@ TEST_F(TestCurrency3, 5)
   int64_t emissionChange = 0;
   uint64_t blockReward = 0;
 
-  bool blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
+  bool blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
                                                 transactionFees, blockReward, emissionChange);
   ASSERT_FALSE(blockTooBig);
   ASSERT_EQ(2554, blockReward);
@@ -688,7 +688,7 @@ TEST_F(TestCurrency3, 6)
   int64_t emissionChange = 0;
   uint64_t blockReward = 0;
 
-  bool blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
+  bool blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
                                                 transactionFees, blockReward, emissionChange);
   ASSERT_FALSE(blockTooBig);
   ASSERT_EQ(0, blockReward);
@@ -707,7 +707,7 @@ TEST_F(TestCurrency3, 7)
   int64_t emissionChange = 0;
   uint64_t blockReward = 0;
 
-  bool blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
+  bool blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins,
                                                 transactionFees, blockReward, emissionChange);
   ASSERT_TRUE(blockTooBig);
   ASSERT_EQ(blockReward, 0);

--- a/tests/Basic/Blockchain/main.cpp
+++ b/tests/Basic/Blockchain/main.cpp
@@ -327,7 +327,7 @@ bool addBlock1(Blockchain& blockchain, Currency& currency, tx_memory_pool& tx_me
   // Must use a while loop find the actual current block size so that the coinbase transaction output amount is correct
   while (true)
   {
-    currency.constructMinerTx(currentBlockchainHeight, medianBlockSize, alreadyGeneratedCoins, currentBlockSize,
+    currency.constructMinerTx1(currentBlockchainHeight, medianBlockSize, alreadyGeneratedCoins, currentBlockSize,
     fee, AccountPublicAddress(), block.baseTransaction, BinaryArray(), maxOuts);
 
     size_t actualBlockSize = getBlockSize(block.baseTransaction, transactions);
@@ -420,7 +420,7 @@ bool addBlock2(Blockchain& blockchain, Currency& currency, tx_memory_pool& tx_me
   // Must use a while loop find the actual current block size so that the coinbase transaction output amount is correct
   while (true)
   {
-    currency.constructMinerTx(currentBlockchainHeight, medianBlockSize, alreadyGeneratedCoins, currentBlockSize,
+    currency.constructMinerTx1(currentBlockchainHeight, medianBlockSize, alreadyGeneratedCoins, currentBlockSize,
     fee, AccountPublicAddress(), block.baseTransaction, BinaryArray(), maxOuts);
 
     size_t actualBlockSize = getBlockSize(block.baseTransaction, transactions);
@@ -508,7 +508,7 @@ bool addBlock3(Blockchain& blockchain, Currency& currency, tx_memory_pool& tx_me
   // Must use a while loop find the actual current block size so that the coinbase transaction output amount is correct
   while (true)
   {
-    currency.constructMinerTx(currentBlockchainHeight, medianBlockSize, alreadyGeneratedCoins, currentBlockSize,
+    currency.constructMinerTx1(currentBlockchainHeight, medianBlockSize, alreadyGeneratedCoins, currentBlockSize,
     fee, AccountPublicAddress(), block.baseTransaction, BinaryArray(), maxOuts);
 
     size_t actualBlockSize = getBlockSize(block.baseTransaction, transactions);
@@ -633,7 +633,7 @@ bool addBlock4(Blockchain& blockchain, Currency& currency, tx_memory_pool& tx_me
   uint64_t fee1 = 0;
   uint64_t reward1;
   int64_t emissionChange1;
-  currency.getBlockReward(medianSize1, currentBlockSize1, alreadyGeneratedCoins1, fee1, reward1, emissionChange1);
+  currency.getBlockReward1(medianSize1, currentBlockSize1, alreadyGeneratedCoins1, fee1, reward1, emissionChange1);
   coinbaseTransactionOutput1.amount = reward1;
 
   // coinbase output target 1
@@ -814,7 +814,7 @@ bool addBlock4(Blockchain& blockchain, Currency& currency, tx_memory_pool& tx_me
   uint64_t fee2 = keyInput2.amount - totalOutputAmount;
   uint64_t reward2;
   int64_t emissionChange2;
-  currency.getBlockReward(medianSize2, currentBlockSize2, alreadyGeneratedCoins2, fee2, reward2, emissionChange2);
+  currency.getBlockReward1(medianSize2, currentBlockSize2, alreadyGeneratedCoins2, fee2, reward2, emissionChange2);
   coinbaseTransactionOutput2.amount = reward2;
 
   // create output target 2
@@ -940,7 +940,7 @@ bool addBlock5(Blockchain& blockchain, Currency& currency, tx_memory_pool& tx_me
   uint64_t fee1 = 0;
   uint64_t reward1;
   int64_t emissionChange1;
-  currency.getBlockReward(medianSize1, currentBlockSize1, alreadyGeneratedCoins1, fee1, reward1, emissionChange1);
+  currency.getBlockReward1(medianSize1, currentBlockSize1, alreadyGeneratedCoins1, fee1, reward1, emissionChange1);
   coinbaseTransactionOutput1.amount = reward1;
 
   // coinbase output target 1
@@ -1117,7 +1117,7 @@ bool addBlock5(Blockchain& blockchain, Currency& currency, tx_memory_pool& tx_me
   uint64_t fee2 = keyInput2.amount - totalOutputAmount;
   uint64_t reward2;
   int64_t emissionChange2;
-  currency.getBlockReward(medianSize2, currentBlockSize2, alreadyGeneratedCoins2, fee2, reward2, emissionChange2);
+  currency.getBlockReward1(medianSize2, currentBlockSize2, alreadyGeneratedCoins2, fee2, reward2, emissionChange2);
   coinbaseTransactionOutput2.amount = reward2;
 
   // create output target 2
@@ -1213,7 +1213,7 @@ bool addBlock7(Blockchain& blockchain, Currency& currency, tx_memory_pool& tx_me
   // Must use a while loop find the actual current block size so that the coinbase transaction output amount is correct
   while (true)
   {
-    currency.constructMinerTx(currentBlockchainHeight, medianBlockSize, alreadyGeneratedCoins, currentBlockSize,
+    currency.constructMinerTx1(currentBlockchainHeight, medianBlockSize, alreadyGeneratedCoins, currentBlockSize,
     fee, AccountPublicAddress(), block.baseTransaction, BinaryArray(), maxOuts);
 
     size_t actualBlockSize = getBlockSize(block.baseTransaction, transactions);
@@ -1310,7 +1310,7 @@ bool addBlock8(Blockchain& blockchain, Currency& currency, tx_memory_pool& tx_me
   // Must use a while loop find the actual current block size so that the coinbase transaction output amount is correct
   while (true)
   {
-    currency.constructMinerTx(currentBlockchainHeight, medianBlockSize, alreadyGeneratedCoins, currentBlockSize,
+    currency.constructMinerTx1(currentBlockchainHeight, medianBlockSize, alreadyGeneratedCoins, currentBlockSize,
     fee, AccountPublicAddress(), block.baseTransaction, BinaryArray(), maxOuts);
 
     size_t actualBlockSize = getBlockSize(block.baseTransaction, transactions);
@@ -1376,7 +1376,7 @@ bool addBlock9(Blockchain& blockchain, Currency& currency, tx_memory_pool& tx_me
   uint64_t fee = 0;
   uint64_t reward;
   int64_t emissionChange;
-  currency.getBlockReward(medianSize, currentBlockSize, alreadyGeneratedCoins, fee, reward, emissionChange);
+  currency.getBlockReward1(medianSize, currentBlockSize, alreadyGeneratedCoins, fee, reward, emissionChange);
   baseOutput.amount = reward;
 
   // create output target
@@ -1514,7 +1514,7 @@ bool addAlternativeBlock(Blockchain& blockchain, Currency& currency, tx_memory_p
 
   while (true)
   {
-    currency.constructMinerTx(blockHeight, medianBlockSize, alreadyGeneratedCoins, currentBlockSize,
+    currency.constructMinerTx1(blockHeight, medianBlockSize, alreadyGeneratedCoins, currentBlockSize,
     fee, AccountPublicAddress(), block.baseTransaction, BinaryArray(), maxOuts);
 
     size_t actualBlockSize = getBlockSize(block.baseTransaction, transactions);
@@ -2130,7 +2130,7 @@ TEST(Blockchain, 19)
   uint64_t fee1 = 0;
   uint64_t reward1;
   int64_t emissionChange1;
-  currency.getBlockReward(medianSize1, currentBlockSize1, alreadyGeneratedCoins1, fee1, reward1, emissionChange1);
+  currency.getBlockReward1(medianSize1, currentBlockSize1, alreadyGeneratedCoins1, fee1, reward1, emissionChange1);
   coinbaseTransactionOutput1.amount = reward1;
 
   // coinbase output target 1
@@ -2433,7 +2433,7 @@ TEST(Blockchain, 24)
   uint64_t fee1 = 0;
   uint64_t reward1;
   int64_t emissionChange1;
-  currency.getBlockReward(medianSize1, currentBlockSize1, alreadyGeneratedCoins1, fee1, reward1, emissionChange1);
+  currency.getBlockReward1(medianSize1, currentBlockSize1, alreadyGeneratedCoins1, fee1, reward1, emissionChange1);
   coinbaseTransactionOutput1.amount = reward1;
 
   // create output target
@@ -2598,7 +2598,7 @@ TEST(Blockchain, 26)
   uint64_t fee1 = 0;
   uint64_t reward1;
   int64_t emissionChange1;
-  currency.getBlockReward(medianSize1, currentBlockSize1, alreadyGeneratedCoins1, fee1, reward1, emissionChange1);
+  currency.getBlockReward1(medianSize1, currentBlockSize1, alreadyGeneratedCoins1, fee1, reward1, emissionChange1);
   coinbaseTransactionOutput1.amount = reward1;
 
   // coinbase output target 1
@@ -2802,7 +2802,7 @@ TEST(Blockchain, 26)
   uint64_t fee2 = totalInputAmount - totalOutputAmount;
   uint64_t reward2;
   int64_t emissionChange2;
-  currency.getBlockReward(medianSize2, currentBlockSize2, alreadyGeneratedCoins2, fee2, reward2, emissionChange2);
+  currency.getBlockReward1(medianSize2, currentBlockSize2, alreadyGeneratedCoins2, fee2, reward2, emissionChange2);
   coinbaseTransactionOutput2.amount = reward2;
 
   // create output target 2

--- a/tests/Basic/Core/main.cpp
+++ b/tests/Basic/Core/main.cpp
@@ -56,7 +56,7 @@ public
   *getBackwardBlocksSizes()
   *getBlockSize()
   *getAlreadyGeneratedCoins()
-  *getBlockReward()
+  *getBlockReward1()
   scanOutputkeysForIndexes()
   *getBlockDifficulty()
   *getBlockContainingTx()
@@ -593,7 +593,7 @@ bool addOrphanBlock(core& core, Crypto::Hash& blockHash, const Crypto::Hash& pre
 
   while (true)
   {
-    currency.constructMinerTx(blockHeight, medianBlockSize, alreadyGeneratedCoins, currentBlockSize,
+    currency.constructMinerTx1(blockHeight, medianBlockSize, alreadyGeneratedCoins, currentBlockSize,
     fee, AccountPublicAddress(), block.baseTransaction, BinaryArray(), maxOuts);
 
     size_t actualBlockSize = getBlockSize(block.baseTransaction, transactions);
@@ -1358,7 +1358,7 @@ TEST(Core, 18)
   ASSERT_EQ(894069671+ 894069618, alreadyGeneratedCoins);
 }
 
-// getBlockReward()
+// getBlockReward1()
 TEST(Core, 19)
 {
   Logging::ConsoleLogger logger;
@@ -1384,7 +1384,7 @@ TEST(Core, 19)
   int64_t emissionChange;
   size_t currentBlockSize = parameters::CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE;
 
-  ASSERT_TRUE(core.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins, fee, reward, emissionChange));
+  ASSERT_TRUE(core.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins, fee, reward, emissionChange));
   ASSERT_EQ(894069618, reward);
 
   // add a block
@@ -1394,7 +1394,7 @@ TEST(Core, 19)
   lastBlockHash = core.get_tail_id();
   core.getAlreadyGeneratedCoins(lastBlockHash, alreadyGeneratedCoins);
 
-  ASSERT_TRUE(core.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins, fee, reward, emissionChange));
+  ASSERT_TRUE(core.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins, fee, reward, emissionChange));
   ASSERT_EQ(894069565, reward);
 }
 

--- a/tests/Basic/Currency/main.cpp
+++ b/tests/Basic/Currency/main.cpp
@@ -59,9 +59,9 @@ public
   isTestnet()
   genesisBlock()
   genesisBlockHash()
-  getBlockReward()
+  getBlockReward1()
   maxBlockCumulativeSize()
-  constructMinerTx()
+  constructMinerTx1()
   accountAddressAsString()
   accountAddressAsString()
   parseAccountAddressString()
@@ -757,7 +757,7 @@ TEST(Currency, 40)
   // just use gdb to see the value of genesisBlockHash
 }
 
-// getBlockReward() 1
+// getBlockReward1() 1
 TEST(Currency, 41)
 {
   size_t medianBlockSize = 1000000;
@@ -773,14 +773,14 @@ TEST(Currency, 41)
 
   Currency currency = currencyBuilder.currency();
 
-  ASSERT_TRUE(currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins, fee, reward, emissionChange));
+  ASSERT_TRUE(currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins, fee, reward, emissionChange));
 
   // baseReward is 0.894069671 plus 0.00000100 fee gives total reward of 0.894069771
   ASSERT_EQ(894069771, reward);
   ASSERT_EQ(894069671, emissionChange);
 }
 
-// getBlockReward() 2
+// getBlockReward1() 2
 TEST(Currency, 42)
 {
   size_t medianBlockSize = 100000;
@@ -795,7 +795,7 @@ TEST(Currency, 42)
   Logging::LoggerGroup logger;
   CurrencyBuilder currencyBuilder(logger);
 
-  ASSERT_TRUE(currencyBuilder.currency().getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins, fee, reward, emissionChange));
+  ASSERT_TRUE(currencyBuilder.currency().getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins, fee, reward, emissionChange));
 
   // baseReward is 0.894069671 plus 0.00000100 fee gives total reward of 0.894069771
   ASSERT_EQ(894069771, reward);
@@ -816,7 +816,7 @@ TEST(Currency, 43)
   ASSERT_EQ(maxBlockCumulativeSize, parameters::MAX_BLOCK_SIZE_INITIAL + (parameters::MAX_BLOCK_SIZE_GROWTH_SPEED_NUMERATOR / parameters::MAX_BLOCK_SIZE_GROWTH_SPEED_DENOMINATOR));
 }
 
-// constructMinerTx()
+// constructMinerTx1()
 TEST(Currency, 44)
 {
   for (uint32_t i = 0; i < loopCount; i++)
@@ -846,7 +846,7 @@ TEST(Currency, 44)
 
     size_t maxOuts = 1;
 
-    ASSERT_TRUE(currency.constructMinerTx(height, medianSize, alreadyGeneratedCoins, currentBlockSize, fee, minerAddress, transaction, extraNonce, maxOuts));
+    ASSERT_TRUE(currency.constructMinerTx1(height, medianSize, alreadyGeneratedCoins, currentBlockSize, fee, minerAddress, transaction, extraNonce, maxOuts));
   }
 }
 

--- a/tests/Basic/TransactionPool/main.cpp
+++ b/tests/Basic/TransactionPool/main.cpp
@@ -49,7 +49,7 @@ public
   lock()
   unlock()
   obtainGuard()
-  fill_block_template()
+  fill_block_template1()
   get_transactions()
   get_difference()
   get_transactions_count()
@@ -378,7 +378,7 @@ TEST(TransactionPool, 14)
   ASSERT_NO_THROW(tx_memory_pool.obtainGuard());
 }
 
-// fill_block_template()
+// fill_block_template1()
 TEST(TransactionPool, 15)
 {
   Logging::ConsoleLogger logger;
@@ -396,7 +396,7 @@ TEST(TransactionPool, 15)
   size_t maxCumulativeSize = 50000;
   uint64_t already_generated_coins = 10;
 
-  ASSERT_TRUE(tx_memory_pool.fill_block_template(block, median_size, maxCumulativeSize, already_generated_coins, total_size, fee));
+  ASSERT_TRUE(tx_memory_pool.fill_block_template1(block, median_size, maxCumulativeSize, already_generated_coins, total_size, fee));
 }
 
 // get_transactions()

--- a/tests/Original/CoreTests/TransactionTests.cpp
+++ b/tests/Original/CoreTests/TransactionTests.cpp
@@ -40,17 +40,17 @@ bool test_transaction_generation_and_ring_signature()
   AccountBase rv_acc2;
   rv_acc2.generate();
   Transaction tx_mine_1;
-  currency.constructMinerTx(0, 0, 0, 10, 0, miner_acc1.getAccountKeys().address, tx_mine_1);
+  currency.constructMinerTx1(0, 0, 0, 10, 0, miner_acc1.getAccountKeys().address, tx_mine_1);
   Transaction tx_mine_2;
-  currency.constructMinerTx(0, 0, 0, 0, 0, miner_acc2.getAccountKeys().address, tx_mine_2);
+  currency.constructMinerTx1(0, 0, 0, 0, 0, miner_acc2.getAccountKeys().address, tx_mine_2);
   Transaction tx_mine_3;
-  currency.constructMinerTx(0, 0, 0, 0, 0, miner_acc3.getAccountKeys().address, tx_mine_3);
+  currency.constructMinerTx1(0, 0, 0, 0, 0, miner_acc3.getAccountKeys().address, tx_mine_3);
   Transaction tx_mine_4;
-  currency.constructMinerTx(0, 0, 0, 0, 0, miner_acc4.getAccountKeys().address, tx_mine_4);
+  currency.constructMinerTx1(0, 0, 0, 0, 0, miner_acc4.getAccountKeys().address, tx_mine_4);
   Transaction tx_mine_5;
-  currency.constructMinerTx(0, 0, 0, 0, 0, miner_acc5.getAccountKeys().address, tx_mine_5);
+  currency.constructMinerTx1(0, 0, 0, 0, 0, miner_acc5.getAccountKeys().address, tx_mine_5);
   Transaction tx_mine_6;
-  currency.constructMinerTx(0, 0, 0, 0, 0, miner_acc6.getAccountKeys().address, tx_mine_6);
+  currency.constructMinerTx1(0, 0, 0, 0, 0, miner_acc6.getAccountKeys().address, tx_mine_6);
 
   //fill inputs entry
   typedef TransactionSourceEntry::OutputEntry tx_output_entry;
@@ -136,7 +136,7 @@ bool test_block_creation()
   bool r = currency.parseAccountAddressString("272xWzbWsP4cfNFfxY5ETN5moU8x81PKfWPwynrrqsNGDBQGLmD1kCkKCvPeDUXu5XfmZkCrQ53wsWmdfvHBGLNjGcRiDcK", adr);
   CHECK_AND_ASSERT_MES(r, false, "failed to import");
   Block b;
-  r = currency.constructMinerTx(90, Common::medianValue(szs), 3553616528562147, 33094, 10000000, adr, b.baseTransaction, BinaryArray(), 11);
+  r = currency.constructMinerTx1(90, Common::medianValue(szs), 3553616528562147, 33094, 10000000, adr, b.baseTransaction, BinaryArray(), 11);
   return r;
 }
 

--- a/tests/Original/PerformanceTests/MultiTransactionTestBase.h
+++ b/tests/Original/PerformanceTests/MultiTransactionTestBase.h
@@ -37,7 +37,7 @@ public:
     {
       m_miners[i].generate();
 
-      if (!currency.constructMinerTx(0, 0, 0, 2, 0, m_miners[i].getAccountKeys().address, m_miner_txs[i]))
+      if (!currency.constructMinerTx1(0, 0, 0, 2, 0, m_miners[i].getAccountKeys().address, m_miner_txs[i]))
         return false;
 
       KeyOutput tx_out = boost::get<KeyOutput>(m_miner_txs[i].outputs[0].target);

--- a/tests/Original/PerformanceTests/SingleTransactionTestBase.h
+++ b/tests/Original/PerformanceTests/SingleTransactionTestBase.h
@@ -21,7 +21,7 @@ public:
     Currency currency = CurrencyBuilder(m_nullLog).currency();
     m_bob.generate();
 
-    if (!currency.constructMinerTx(0, 0, 0, 2, 0, m_bob.getAccountKeys().address, m_tx))
+    if (!currency.constructMinerTx1(0, 0, 0, 2, 0, m_bob.getAccountKeys().address, m_tx))
       return false;
 
     m_tx_pub_key = getTransactionPublicKeyFromExtra(m_tx.extra);

--- a/tests/Original/TestGenerator/TestGenerator.cpp
+++ b/tests/Original/TestGenerator/TestGenerator.cpp
@@ -62,7 +62,7 @@ void test_generator::addBlock(const CryptoNote::Block& blk, size_t tsxSize, uint
   const size_t blockSize = tsxSize + getObjectBinarySize(blk.baseTransaction);
   int64_t emissionChange;
   uint64_t blockReward;
-  m_currency.getBlockReward(Common::medianValue(blockSizes), blockSize, alreadyGeneratedCoins, fee,
+  m_currency.getBlockReward1(Common::medianValue(blockSizes), blockSize, alreadyGeneratedCoins, fee,
     blockReward, emissionChange);
   m_blocksInfo[get_block_hash(blk)] = BlockInfo(blk.previousBlockHash, alreadyGeneratedCoins + emissionChange, blockSize);
 }
@@ -93,7 +93,7 @@ bool test_generator::constructBlock(CryptoNote::Block& blk, uint32_t height, con
   blk.baseTransaction = boost::value_initialized<Transaction>();
   size_t targetBlockSize = txsSize + getObjectBinarySize(blk.baseTransaction);
   while (true) {
-    if (!m_currency.constructMinerTx(height, Common::medianValue(blockSizes), alreadyGeneratedCoins, targetBlockSize,
+    if (!m_currency.constructMinerTx1(height, Common::medianValue(blockSizes), alreadyGeneratedCoins, targetBlockSize,
       totalFee, minerAcc.getAccountKeys().address, blk.baseTransaction, BinaryArray(), 10)) {
       return false;
     }
@@ -177,7 +177,7 @@ bool test_generator::constructBlockManually(Block& blk, const Block& prevBlock, 
     blk.baseTransaction = boost::value_initialized<Transaction>();
     size_t currentBlockSize = txsSizes + getObjectBinarySize(blk.baseTransaction);
     // TODO: This will work, until size of constructed block is less then m_currency.blockGrantedFullRewardZone()
-    if (!m_currency.constructMinerTx(height, Common::medianValue(blockSizes), alreadyGeneratedCoins, currentBlockSize, 0,
+    if (!m_currency.constructMinerTx1(height, Common::medianValue(blockSizes), alreadyGeneratedCoins, currentBlockSize, 0,
       minerAcc.getAccountKeys().address, blk.baseTransaction, BinaryArray(), 1)) {
         return false;
     }
@@ -258,7 +258,7 @@ bool constructMinerTxManually(const CryptoNote::Currency& currency, uint32_t hei
   // This will work, until size of constructed block is less then currency.blockGrantedFullRewardZone()
   int64_t emissionChange;
   uint64_t blockReward;
-  if (!currency.getBlockReward(0, 0, alreadyGeneratedCoins, fee, blockReward, emissionChange)) {
+  if (!currency.getBlockReward1(0, 0, alreadyGeneratedCoins, fee, blockReward, emissionChange)) {
     std::cerr << "Block is too big" << std::endl;
     return false;
   }
@@ -283,7 +283,7 @@ bool constructMinerTxBySize(const CryptoNote::Currency& currency, CryptoNote::Tr
                             uint64_t alreadyGeneratedCoins, const CryptoNote::AccountPublicAddress& minerAddress,
                             std::vector<size_t>& blockSizes, size_t targetTxSize, size_t targetBlockSize,
                             uint64_t fee/* = 0*/) {
-  if (!currency.constructMinerTx(height, Common::medianValue(blockSizes), alreadyGeneratedCoins, targetBlockSize,
+  if (!currency.constructMinerTx1(height, Common::medianValue(blockSizes), alreadyGeneratedCoins, targetBlockSize,
       fee, minerAddress, baseTransaction, CryptoNote::BinaryArray(), 1)) {
     return false;
   }

--- a/tests/Original/TestWallet/TestGenerator/TestGenerator.cpp
+++ b/tests/Original/TestWallet/TestGenerator/TestGenerator.cpp
@@ -62,7 +62,7 @@ void test_generator::addBlock(const CryptoNote::Block& blk, size_t tsxSize, uint
   const size_t blockSize = tsxSize + getObjectBinarySize(blk.baseTransaction);
   int64_t emissionChange;
   uint64_t blockReward;
-  m_currency.getBlockReward(Common::medianValue(blockSizes), blockSize, alreadyGeneratedCoins, fee,
+  m_currency.getBlockReward1(Common::medianValue(blockSizes), blockSize, alreadyGeneratedCoins, fee,
     blockReward, emissionChange);
   m_blocksInfo[get_block_hash(blk)] = BlockInfo(blk.previousBlockHash, alreadyGeneratedCoins + emissionChange, blockSize);
 }
@@ -93,7 +93,7 @@ bool test_generator::constructBlock(CryptoNote::Block& blk, uint32_t height, con
   blk.baseTransaction = boost::value_initialized<Transaction>();
   size_t targetBlockSize = txsSize + getObjectBinarySize(blk.baseTransaction);
   while (true) {
-    if (!m_currency.constructMinerTx(height, Common::medianValue(blockSizes), alreadyGeneratedCoins, targetBlockSize,
+    if (!m_currency.constructMinerTx1(height, Common::medianValue(blockSizes), alreadyGeneratedCoins, targetBlockSize,
       totalFee, minerAcc.getAccountKeys().address, blk.baseTransaction, BinaryArray(), 10)) {
       return false;
     }
@@ -178,7 +178,7 @@ bool test_generator::constructBlockManually(Block& blk, const Block& prevBlock, 
     blk.baseTransaction = boost::value_initialized<Transaction>();
     size_t currentBlockSize = txsSizes + getObjectBinarySize(blk.baseTransaction);
     // TODO: This will work, until size of constructed block is less then m_currency.blockGrantedFullRewardZone()
-    if (!m_currency.constructMinerTx(height, Common::medianValue(blockSizes), alreadyGeneratedCoins, currentBlockSize, 0,
+    if (!m_currency.constructMinerTx1(height, Common::medianValue(blockSizes), alreadyGeneratedCoins, currentBlockSize, 0,
       minerAcc.getAccountKeys().address, blk.baseTransaction, BinaryArray(), 1)) {
         return false;
     }
@@ -259,7 +259,7 @@ bool constructMinerTxManually(const CryptoNote::Currency& currency, uint32_t hei
   // This will work, until size of constructed block is less then currency.blockGrantedFullRewardZone()
   int64_t emissionChange;
   uint64_t blockReward;
-  if (!currency.getBlockReward(0, 0, alreadyGeneratedCoins, fee, blockReward, emissionChange)) {
+  if (!currency.getBlockReward1(0, 0, alreadyGeneratedCoins, fee, blockReward, emissionChange)) {
     std::cerr << "Block is too big" << std::endl;
     return false;
   }
@@ -284,7 +284,7 @@ bool constructMinerTxBySize(const CryptoNote::Currency& currency, CryptoNote::Tr
                             uint64_t alreadyGeneratedCoins, const CryptoNote::AccountPublicAddress& minerAddress,
                             std::vector<size_t>& blockSizes, size_t targetTxSize, size_t targetBlockSize,
                             uint64_t fee/* = 0*/) {
-  if (!currency.constructMinerTx(height, Common::medianValue(blockSizes), alreadyGeneratedCoins, targetBlockSize,
+  if (!currency.constructMinerTx1(height, Common::medianValue(blockSizes), alreadyGeneratedCoins, targetBlockSize,
       fee, minerAddress, baseTransaction, CryptoNote::BinaryArray(), 1)) {
     return false;
   }

--- a/tests/Original/TransactionPool/TestGenerator/TestGenerator.cpp
+++ b/tests/Original/TransactionPool/TestGenerator/TestGenerator.cpp
@@ -62,7 +62,7 @@ void test_generator::addBlock(const CryptoNote::Block& blk, size_t tsxSize, uint
   const size_t blockSize = tsxSize + getObjectBinarySize(blk.baseTransaction);
   int64_t emissionChange;
   uint64_t blockReward;
-  m_currency.getBlockReward(Common::medianValue(blockSizes), blockSize, alreadyGeneratedCoins, fee,
+  m_currency.getBlockReward1(Common::medianValue(blockSizes), blockSize, alreadyGeneratedCoins, fee,
     blockReward, emissionChange);
   m_blocksInfo[get_block_hash(blk)] = BlockInfo(blk.previousBlockHash, alreadyGeneratedCoins + emissionChange, blockSize);
 }
@@ -93,7 +93,7 @@ bool test_generator::constructBlock(CryptoNote::Block& blk, uint32_t height, con
   blk.baseTransaction = boost::value_initialized<Transaction>();
   size_t targetBlockSize = txsSize + getObjectBinarySize(blk.baseTransaction);
   while (true) {
-    if (!m_currency.constructMinerTx(height, Common::medianValue(blockSizes), alreadyGeneratedCoins, targetBlockSize,
+    if (!m_currency.constructMinerTx1(height, Common::medianValue(blockSizes), alreadyGeneratedCoins, targetBlockSize,
       totalFee, minerAcc.getAccountKeys().address, blk.baseTransaction, BinaryArray(), 10)) {
       return false;
     }
@@ -178,7 +178,7 @@ bool test_generator::constructBlockManually(Block& blk, const Block& prevBlock, 
     blk.baseTransaction = boost::value_initialized<Transaction>();
     size_t currentBlockSize = txsSizes + getObjectBinarySize(blk.baseTransaction);
     // TODO: This will work, until size of constructed block is less then m_currency.blockGrantedFullRewardZone()
-    if (!m_currency.constructMinerTx(height, Common::medianValue(blockSizes), alreadyGeneratedCoins, currentBlockSize, 0,
+    if (!m_currency.constructMinerTx1(height, Common::medianValue(blockSizes), alreadyGeneratedCoins, currentBlockSize, 0,
       minerAcc.getAccountKeys().address, blk.baseTransaction, BinaryArray(), 1)) {
         return false;
     }
@@ -259,7 +259,7 @@ bool constructMinerTxManually(const CryptoNote::Currency& currency, uint32_t hei
   // This will work, until size of constructed block is less then currency.blockGrantedFullRewardZone()
   int64_t emissionChange;
   uint64_t blockReward;
-  if (!currency.getBlockReward(0, 0, alreadyGeneratedCoins, fee, blockReward, emissionChange)) {
+  if (!currency.getBlockReward1(0, 0, alreadyGeneratedCoins, fee, blockReward, emissionChange)) {
     std::cerr << "Block is too big" << std::endl;
     return false;
   }
@@ -284,7 +284,7 @@ bool constructMinerTxBySize(const CryptoNote::Currency& currency, CryptoNote::Tr
                             uint64_t alreadyGeneratedCoins, const CryptoNote::AccountPublicAddress& minerAddress,
                             std::vector<size_t>& blockSizes, size_t targetTxSize, size_t targetBlockSize,
                             uint64_t fee/* = 0*/) {
-  if (!currency.constructMinerTx(height, Common::medianValue(blockSizes), alreadyGeneratedCoins, targetBlockSize,
+  if (!currency.constructMinerTx1(height, Common::medianValue(blockSizes), alreadyGeneratedCoins, targetBlockSize,
       fee, minerAddress, baseTransaction, CryptoNote::BinaryArray(), 1)) {
     return false;
   }

--- a/tests/Original/TransactionPool/TransactionPool.cpp
+++ b/tests/Original/TransactionPool/TransactionPool.cpp
@@ -75,7 +75,7 @@ public:
     {
       m_miners[i].generate();
 
-      if (!m_currency.constructMinerTx(0, 0, 0, 2, 0, m_miners[i].getAccountKeys().address, m_miner_txs[i])) {
+      if (!m_currency.constructMinerTx1(0, 0, 0, 2, 0, m_miners[i].getAccountKeys().address, m_miner_txs[i])) {
         return false;
       }
 
@@ -288,7 +288,7 @@ TEST_F(tx_pool, DISABLED_fillblock_same_fee)
   uint64_t txFee = 0;
   uint64_t median = 5000;
 
-  ASSERT_TRUE(pool.fill_block_template(bl, median, textMaxCumulativeSize, 0, totalSize, txFee));
+  ASSERT_TRUE(pool.fill_block_template1(bl, median, textMaxCumulativeSize, 0, totalSize, txFee));
   ASSERT_TRUE(totalSize <= 2 * median);
 
   // now, check that the block is opimally filled
@@ -348,7 +348,7 @@ TEST_F(tx_pool, DISABLED_fillblock_same_size)
   uint64_t txFee = 0;
   uint64_t median = 5000;
 
-  ASSERT_TRUE(pool.fill_block_template(bl, median, textMaxCumulativeSize, 0, totalSize, txFee));
+  ASSERT_TRUE(pool.fill_block_template1(bl, median, textMaxCumulativeSize, 0, totalSize, txFee));
   ASSERT_TRUE(totalSize <= 2 * median);
 
   // check that fill_block_template prefers transactions with double fee
@@ -759,7 +759,7 @@ public:
     Block block;
     size_t totalSize;
     uint64_t totalFee;
-    ASSERT_TRUE(pool->fill_block_template(block, currency.blockGrantedFullRewardZone(), std::numeric_limits<size_t>::max(), 0, totalSize, totalFee));
+    ASSERT_TRUE(pool->fill_block_template1(block, currency.blockGrantedFullRewardZone(), std::numeric_limits<size_t>::max(), 0, totalSize, totalFee));
 
     size_t fusionTxCount = 0;
     size_t ordinaryTxCount = 0;

--- a/tests/Original/UnitTests/BlockReward.cpp
+++ b/tests/Original/UnitTests/BlockReward.cpp
@@ -18,9 +18,9 @@ namespace
   const uint64_t TEST_EMISSION_SPEED_FACTOR = 18;
 
   //--------------------------------------------------------------------------------------------------------------------
-  class getBlockReward_and_already_generated_coins : public ::testing::Test {
+  class getBlockReward1_and_already_generated_coins : public ::testing::Test {
   public:
-    getBlockReward_and_already_generated_coins() :
+    getBlockReward1_and_already_generated_coins() :
       ::testing::Test(),
       m_currency(CryptoNote::CurrencyBuilder(m_logger).
         blockGrantedFullRewardZone(TEST_GRANTED_FULL_REWARD_ZONE).
@@ -40,25 +40,25 @@ namespace
   };
 
   #define TEST_ALREADY_GENERATED_COINS(alreadyGeneratedCoins, expectedReward)                                  \
-    m_blockTooBig = !m_currency.getBlockReward(0, currentBlockSize, alreadyGeneratedCoins, 0,                  \
+    m_blockTooBig = !m_currency.getBlockReward1(0, currentBlockSize, alreadyGeneratedCoins, 0,                  \
       m_blockReward, m_emissionChange);                                                                        \
     ASSERT_FALSE(m_blockTooBig);                                                                               \
     ASSERT_EQ(UINT64_C(expectedReward), m_blockReward);                                                        \
     ASSERT_EQ(UINT64_C(expectedReward), m_emissionChange);
 
-  TEST_F(getBlockReward_and_already_generated_coins, handles_first_values) {
+  TEST_F(getBlockReward1_and_already_generated_coins, handles_first_values) {
     TEST_ALREADY_GENERATED_COINS(0, 70368744177663);
     TEST_ALREADY_GENERATED_COINS(m_blockReward, 70368475742208);
     TEST_ALREADY_GENERATED_COINS(UINT64_C(2756434948434199641), 59853779316998);
   }
 
-  TEST_F(getBlockReward_and_already_generated_coins, correctly_steps_from_reward_2_to_1) {
+  TEST_F(getBlockReward1_and_already_generated_coins, correctly_steps_from_reward_2_to_1) {
     TEST_ALREADY_GENERATED_COINS(m_currency.moneySupply() - ((UINT64_C(2) << m_currency.emissionSpeedFactor()) + 1), 2);
     TEST_ALREADY_GENERATED_COINS(m_currency.moneySupply() -  (UINT64_C(2) << m_currency.emissionSpeedFactor())     , 2);
     TEST_ALREADY_GENERATED_COINS(m_currency.moneySupply() - ((UINT64_C(2) << m_currency.emissionSpeedFactor()) - 1), 1);
   }
 
-  TEST_F(getBlockReward_and_already_generated_coins, handles_max_already_generaged_coins) {
+  TEST_F(getBlockReward1_and_already_generated_coins, handles_max_already_generaged_coins) {
     TEST_ALREADY_GENERATED_COINS(m_currency.moneySupply() - ((UINT64_C(1) << m_currency.emissionSpeedFactor()) + 1), 1);
     TEST_ALREADY_GENERATED_COINS(m_currency.moneySupply() -  (UINT64_C(1) << m_currency.emissionSpeedFactor())     , 1);
     TEST_ALREADY_GENERATED_COINS(m_currency.moneySupply() - ((UINT64_C(1) << m_currency.emissionSpeedFactor()) - 1), 0);
@@ -67,9 +67,9 @@ namespace
   }
 
   //--------------------------------------------------------------------------------------------------------------------
-  class getBlockReward_and_median_and_blockSize : public ::testing::Test {
+  class getBlockReward1_and_median_and_blockSize : public ::testing::Test {
   public:
-    getBlockReward_and_median_and_blockSize() :
+    getBlockReward1_and_median_and_blockSize() :
       ::testing::Test(),
       m_currency(CryptoNote::CurrencyBuilder(m_logger).
         blockGrantedFullRewardZone(TEST_GRANTED_FULL_REWARD_ZONE).
@@ -82,14 +82,14 @@ namespace
     static const uint64_t alreadyGeneratedCoins = 0;
 
     virtual void SetUp() override {
-      m_blockTooBig = !m_currency.getBlockReward(0, 0, alreadyGeneratedCoins, 0,
+      m_blockTooBig = !m_currency.getBlockReward1(0, 0, alreadyGeneratedCoins, 0,
         m_standardBlockReward, m_emissionChange);
       ASSERT_FALSE(m_blockTooBig);
       ASSERT_EQ(UINT64_C(70368744177663), m_standardBlockReward);
     }
 
     void do_test(size_t medianBlockSize, size_t currentBlockSize) {
-      m_blockTooBig = !m_currency.getBlockReward(medianBlockSize, currentBlockSize, alreadyGeneratedCoins, 0,
+      m_blockTooBig = !m_currency.getBlockReward1(medianBlockSize, currentBlockSize, alreadyGeneratedCoins, 0,
         m_blockReward, m_emissionChange);
     }
 
@@ -101,31 +101,31 @@ namespace
     uint64_t m_standardBlockReward;
   };
 
-  TEST_F(getBlockReward_and_median_and_blockSize, handles_zero_median) {
+  TEST_F(getBlockReward1_and_median_and_blockSize, handles_zero_median) {
     do_test(0, TEST_GRANTED_FULL_REWARD_ZONE);
     ASSERT_FALSE(m_blockTooBig);
     ASSERT_EQ(m_standardBlockReward, m_blockReward);
   }
 
-  TEST_F(getBlockReward_and_median_and_blockSize, handles_median_lt_relevance_level) {
+  TEST_F(getBlockReward1_and_median_and_blockSize, handles_median_lt_relevance_level) {
     do_test(TEST_GRANTED_FULL_REWARD_ZONE - 1, TEST_GRANTED_FULL_REWARD_ZONE);
     ASSERT_FALSE(m_blockTooBig);
     ASSERT_EQ(m_standardBlockReward, m_blockReward);
   }
 
-  TEST_F(getBlockReward_and_median_and_blockSize, handles_median_eq_relevance_level) {
+  TEST_F(getBlockReward1_and_median_and_blockSize, handles_median_eq_relevance_level) {
     do_test(TEST_GRANTED_FULL_REWARD_ZONE, TEST_GRANTED_FULL_REWARD_ZONE - 1);
     ASSERT_FALSE(m_blockTooBig);
     ASSERT_EQ(m_standardBlockReward, m_blockReward);
   }
 
-  TEST_F(getBlockReward_and_median_and_blockSize, handles_median_gt_relevance_level) {
+  TEST_F(getBlockReward1_and_median_and_blockSize, handles_median_gt_relevance_level) {
     do_test(TEST_GRANTED_FULL_REWARD_ZONE + 1, TEST_GRANTED_FULL_REWARD_ZONE);
     ASSERT_FALSE(m_blockTooBig);
     ASSERT_EQ(m_standardBlockReward, m_blockReward);
   }
 
-  TEST_F(getBlockReward_and_median_and_blockSize, handles_big_median) {
+  TEST_F(getBlockReward1_and_median_and_blockSize, handles_big_median) {
     size_t blockSize = 1;
     size_t medianSize = std::numeric_limits<uint32_t>::max();
 
@@ -135,7 +135,7 @@ namespace
     ASSERT_EQ(m_standardBlockReward, m_blockReward);
   }
 
-  TEST_F(getBlockReward_and_median_and_blockSize, handles_big_block_size) {
+  TEST_F(getBlockReward1_and_median_and_blockSize, handles_big_block_size) {
     size_t blockSize = std::numeric_limits<uint32_t>::max() - 1; // even
     size_t medianSize = blockSize / 2; // 2 * medianSize == blockSize
 
@@ -144,7 +144,7 @@ namespace
     ASSERT_EQ(0, m_blockReward);
   }
 
-  TEST_F(getBlockReward_and_median_and_blockSize, handles_big_block_size_fail) {
+  TEST_F(getBlockReward1_and_median_and_blockSize, handles_big_block_size_fail) {
     size_t blockSize = std::numeric_limits<uint32_t>::max();
     size_t medianSize = blockSize / 2 - 1;
 
@@ -152,7 +152,7 @@ namespace
     ASSERT_TRUE(m_blockTooBig);
   }
 
-  TEST_F(getBlockReward_and_median_and_blockSize, handles_big_median_and_block_size) {
+  TEST_F(getBlockReward1_and_median_and_blockSize, handles_big_median_and_block_size) {
     // blockSize should be greater medianSize
     size_t blockSize = std::numeric_limits<uint32_t>::max();
     size_t medianSize = std::numeric_limits<uint32_t>::max() - 1;
@@ -163,9 +163,9 @@ namespace
   }
 
   //--------------------------------------------------------------------------------------------------------------------
-  class getBlockReward_and_currentBlockSize : public ::testing::Test {
+  class getBlockReward1_and_currentBlockSize : public ::testing::Test {
   public:
-    getBlockReward_and_currentBlockSize() :
+    getBlockReward1_and_currentBlockSize() :
       ::testing::Test(),
       m_currency(CryptoNote::CurrencyBuilder(m_logger).
         blockGrantedFullRewardZone(TEST_GRANTED_FULL_REWARD_ZONE).
@@ -179,7 +179,7 @@ namespace
     static const uint64_t alreadyGeneratedCoins = 0;
 
     virtual void SetUp() override {
-      m_blockTooBig = !m_currency.getBlockReward(testMedian, 0, alreadyGeneratedCoins, 0,
+      m_blockTooBig = !m_currency.getBlockReward1(testMedian, 0, alreadyGeneratedCoins, 0,
         m_standardBlockReward, m_emissionChange);
 
       ASSERT_FALSE(m_blockTooBig);
@@ -187,7 +187,7 @@ namespace
     }
 
     void do_test(size_t currentBlockSize) {
-      m_blockTooBig = !m_currency.getBlockReward(testMedian, currentBlockSize, alreadyGeneratedCoins, 0,
+      m_blockTooBig = !m_currency.getBlockReward1(testMedian, currentBlockSize, alreadyGeneratedCoins, 0,
         m_blockReward, m_emissionChange);
     }
 
@@ -199,49 +199,49 @@ namespace
     uint64_t m_standardBlockReward;
   };
 
-  TEST_F(getBlockReward_and_currentBlockSize, handles_zero_block_size) {
+  TEST_F(getBlockReward1_and_currentBlockSize, handles_zero_block_size) {
     do_test(0);
     ASSERT_FALSE(m_blockTooBig);
     ASSERT_EQ(m_standardBlockReward, m_blockReward);
   }
 
-  TEST_F(getBlockReward_and_currentBlockSize, handles_block_size_less_median) {
+  TEST_F(getBlockReward1_and_currentBlockSize, handles_block_size_less_median) {
     do_test(testMedian - 1);
     ASSERT_FALSE(m_blockTooBig);
     ASSERT_EQ(m_standardBlockReward, m_blockReward);
   }
 
-  TEST_F(getBlockReward_and_currentBlockSize, handles_block_size_eq_median) {
+  TEST_F(getBlockReward1_and_currentBlockSize, handles_block_size_eq_median) {
     do_test(testMedian);
     ASSERT_FALSE(m_blockTooBig);
     ASSERT_EQ(m_standardBlockReward, m_blockReward);
   }
 
-  TEST_F(getBlockReward_and_currentBlockSize, handles_block_size_gt_median) {
+  TEST_F(getBlockReward1_and_currentBlockSize, handles_block_size_gt_median) {
     do_test(testMedian + 1);
     ASSERT_FALSE(m_blockTooBig);
     ASSERT_LT(m_blockReward, m_standardBlockReward);
   }
 
-  TEST_F(getBlockReward_and_currentBlockSize, handles_block_size_less_2_medians) {
+  TEST_F(getBlockReward1_and_currentBlockSize, handles_block_size_less_2_medians) {
     do_test(2 * testMedian - 1);
     ASSERT_FALSE(m_blockTooBig);
     ASSERT_LT(m_blockReward, m_standardBlockReward);
     ASSERT_GT(m_blockReward, 0);
   }
 
-  TEST_F(getBlockReward_and_currentBlockSize, handles_block_size_eq_2_medians) {
+  TEST_F(getBlockReward1_and_currentBlockSize, handles_block_size_eq_2_medians) {
     do_test(2 * testMedian);
     ASSERT_FALSE(m_blockTooBig);
     ASSERT_EQ(0, m_blockReward);
   }
 
-  TEST_F(getBlockReward_and_currentBlockSize, handles_block_size_gt_2_medians) {
+  TEST_F(getBlockReward1_and_currentBlockSize, handles_block_size_gt_2_medians) {
     do_test(2 * testMedian + 1);
     ASSERT_TRUE(m_blockTooBig);
   }
 
-  TEST_F(getBlockReward_and_currentBlockSize, calculates_correctly) {
+  TEST_F(getBlockReward1_and_currentBlockSize, calculates_correctly) {
     ASSERT_EQ(0, testMedian % 8);
 
     // reward = 1 - (k - 1)^2
@@ -269,9 +269,9 @@ namespace
   const uint64_t expectedBaseReward = 62500000;  // testMoneySupply >> testEmissionSpeedFactor
   const uint64_t expectedBlockReward = 22500000; // expectedBaseReward - expectedBaseReward * testPenalty / 100
   //--------------------------------------------------------------------------------------------------------------------
-  class getBlockReward_fee_and_penalizeFee_test : public ::testing::Test {
+  class getBlockReward1_fee_and_penalizeFee_test : public ::testing::Test {
   public:
-    getBlockReward_fee_and_penalizeFee_test() :
+    getBlockReward1_fee_and_penalizeFee_test() :
       ::testing::Test(),
       m_currency(CryptoNote::CurrencyBuilder(m_logger).
         blockGrantedFullRewardZone(testGrantedFullRewardZone).
@@ -285,7 +285,7 @@ namespace
       uint64_t blockReward;
       int64_t emissionChange;
 
-      m_blockTooBig = !m_currency.getBlockReward(testMedian, testBlockSize, 0, 0, blockReward, emissionChange);
+      m_blockTooBig = !m_currency.getBlockReward1(testMedian, testBlockSize, 0, 0, blockReward, emissionChange);
 
       ASSERT_FALSE(m_blockTooBig);
       ASSERT_EQ(expectedBlockReward, blockReward);
@@ -293,7 +293,7 @@ namespace
     }
 
     void do_test(uint64_t alreadyGeneratedCoins, uint64_t fee) {
-      m_blockTooBig = !m_currency.getBlockReward(testMedian, testBlockSize, alreadyGeneratedCoins, fee,
+      m_blockTooBig = !m_currency.getBlockReward1(testMedian, testBlockSize, alreadyGeneratedCoins, fee,
         m_blockReward, m_emissionChange);
     }
 
@@ -304,7 +304,7 @@ namespace
     uint64_t m_blockReward;
   };
 
-  TEST_F(getBlockReward_fee_and_penalizeFee_test, handles_zero_fee_and_penalize_fee) {
+  TEST_F(getBlockReward1_fee_and_penalizeFee_test, handles_zero_fee_and_penalize_fee) {
     do_test(0, 0);
 
     ASSERT_FALSE(m_blockTooBig);
@@ -313,7 +313,7 @@ namespace
     ASSERT_GT(m_emissionChange, 0);
   }
 
-  TEST_F(getBlockReward_fee_and_penalizeFee_test, handles_fee_lt_block_reward_and_penalize_fee) {
+  TEST_F(getBlockReward1_fee_and_penalizeFee_test, handles_fee_lt_block_reward_and_penalize_fee) {
     uint64_t fee = expectedBlockReward / 2;
     do_test(0, fee);
 
@@ -323,7 +323,7 @@ namespace
     ASSERT_GT(m_emissionChange, 0);
   }
 
-  TEST_F(getBlockReward_fee_and_penalizeFee_test, handles_fee_eq_block_reward_and_penalize_fee) {
+  TEST_F(getBlockReward1_fee_and_penalizeFee_test, handles_fee_eq_block_reward_and_penalize_fee) {
     uint64_t fee = expectedBlockReward;
     do_test(0, fee);
 
@@ -333,7 +333,7 @@ namespace
     ASSERT_GT(m_emissionChange, 0);
   }
 
-  TEST_F(getBlockReward_fee_and_penalizeFee_test, handles_fee_gt_block_reward_and_penalize_fee) {
+  TEST_F(getBlockReward1_fee_and_penalizeFee_test, handles_fee_gt_block_reward_and_penalize_fee) {
     uint64_t fee = 2 * expectedBlockReward;
     do_test(0, fee);
 
@@ -343,7 +343,7 @@ namespace
     ASSERT_LT(m_emissionChange, 0);
   }
 
-  TEST_F(getBlockReward_fee_and_penalizeFee_test, handles_emission_change_eq_zero) {
+  TEST_F(getBlockReward1_fee_and_penalizeFee_test, handles_emission_change_eq_zero) {
     uint64_t fee = expectedBlockReward * 100 / testPenalty;
     do_test(0, fee);
 
@@ -352,7 +352,7 @@ namespace
     ASSERT_EQ(0, m_emissionChange);
   }
 
-  TEST_F(getBlockReward_fee_and_penalizeFee_test, handles_fee_if_block_reward_is_zero_and_penalize_fee) {
+  TEST_F(getBlockReward1_fee_and_penalizeFee_test, handles_fee_if_block_reward_is_zero_and_penalize_fee) {
     uint64_t fee = UINT64_C(100);
     do_test(m_currency.moneySupply(), fee);
 

--- a/tests/Original/UnitTests/ICoreStub.cpp
+++ b/tests/Original/UnitTests/ICoreStub.cpp
@@ -245,7 +245,12 @@ bool ICoreStub::getAlreadyGeneratedCoins(const Crypto::Hash& hash, uint64_t& gen
   return true;
 }
 
-bool ICoreStub::getBlockReward(size_t medianSize, size_t currentBlockSize, uint64_t alreadyGeneratedCoins, uint64_t fee,
+bool ICoreStub::getBlockReward1(size_t medianSize, size_t currentBlockSize, uint64_t alreadyGeneratedCoins, uint64_t fee,
+    uint64_t& reward, int64_t& emissionChange) {
+  return true;
+}
+
+bool ICoreStub::getBlockReward2(uint32_t blockHeight, size_t currentBlockSize, uint64_t alreadyGeneratedCoins, uint64_t fee,
     uint64_t& reward, int64_t& emissionChange) {
   return true;
 }

--- a/tests/Original/UnitTests/ICoreStub.h
+++ b/tests/Original/UnitTests/ICoreStub.h
@@ -61,7 +61,9 @@ public:
   virtual bool getBackwardBlocksSizes(uint32_t fromHeight, std::vector<size_t>& sizes, size_t count) override;
   virtual bool getBlockSize(const Crypto::Hash& hash, size_t& size) override;
   virtual bool getAlreadyGeneratedCoins(const Crypto::Hash& hash, uint64_t& generatedCoins) override;
-  virtual bool getBlockReward(size_t medianSize, size_t currentBlockSize, uint64_t alreadyGeneratedCoins, uint64_t fee,
+  virtual bool getBlockReward1(size_t medianSize, size_t currentBlockSize, uint64_t alreadyGeneratedCoins, uint64_t fee,
+      uint64_t& reward, int64_t& emissionChange) override;
+  virtual bool getBlockReward2(uint32_t blockHeight, size_t currentBlockSize, uint64_t alreadyGeneratedCoins, uint64_t fee,
       uint64_t& reward, int64_t& emissionChange) override;
   virtual bool scanOutputkeysForIndexes(const CryptoNote::KeyInput& txInToKey, std::list<std::pair<Crypto::Hash, size_t>>& outputReferences) override;
   virtual bool getBlockDifficulty(uint32_t height, CryptoNote::difficulty_type& difficulty) override;

--- a/tests/Original/UnitTests/TestFormatUtils.cpp
+++ b/tests/Original/UnitTests/TestFormatUtils.cpp
@@ -120,7 +120,7 @@ TEST(parse_and_validate_tx_extra, is_valid_tx_extra_parsed)
   CryptoNote::AccountBase acc;
   acc.generate();
   CryptoNote::BinaryArray b = Common::asBinaryArray("dsdsdfsdfsf");
-  ASSERT_TRUE(currency.constructMinerTx(0, 0, 10000000000000, 1000, currency.minimumFee(), acc.getAccountKeys().address, tx, b, 1));
+  ASSERT_TRUE(currency.constructMinerTx1(0, 0, 10000000000000, 1000, currency.minimumFee(), acc.getAccountKeys().address, tx, b, 1));
   Crypto::PublicKey tx_pub_key = CryptoNote::getTransactionPublicKeyFromExtra(tx.extra);
   ASSERT_NE(tx_pub_key, CryptoNote::NULL_PUBLIC_KEY);
 }
@@ -132,7 +132,7 @@ TEST(parse_and_validate_tx_extra, fails_on_big_extra_nonce)
   CryptoNote::AccountBase acc;
   acc.generate();
   CryptoNote::BinaryArray b(TX_EXTRA_NONCE_MAX_COUNT + 1, 0);
-  ASSERT_FALSE(currency.constructMinerTx(0, 0, 10000000000000, 1000, currency.minimumFee(), acc.getAccountKeys().address, tx, b, 1));
+  ASSERT_FALSE(currency.constructMinerTx1(0, 0, 10000000000000, 1000, currency.minimumFee(), acc.getAccountKeys().address, tx, b, 1));
 }
 TEST(parse_and_validate_tx_extra, fails_on_wrong_size_in_extra_nonce)
 {

--- a/tests/Original/UnitTests/TransactionPool.cpp
+++ b/tests/Original/UnitTests/TransactionPool.cpp
@@ -75,7 +75,7 @@ public:
     {
       m_miners[i].generate();
 
-      if (!m_currency.constructMinerTx(0, 0, 0, 2, 0, m_miners[i].getAccountKeys().address, m_miner_txs[i])) {
+      if (!m_currency.constructMinerTx1(0, 0, 0, 2, 0, m_miners[i].getAccountKeys().address, m_miner_txs[i])) {
         return false;
       }
 
@@ -288,7 +288,7 @@ TEST_F(tx_pool, DISABLED_fillblock_same_fee)
   uint64_t txFee = 0;
   uint64_t median = 5000;
 
-  ASSERT_TRUE(pool.fill_block_template(bl, median, textMaxCumulativeSize, 0, totalSize, txFee));
+  ASSERT_TRUE(pool.fill_block_template1(bl, median, textMaxCumulativeSize, 0, totalSize, txFee));
   ASSERT_TRUE(totalSize <= 2 * median);
 
   // now, check that the block is opimally filled
@@ -348,7 +348,7 @@ TEST_F(tx_pool, DISABLED_fillblock_same_size)
   uint64_t txFee = 0;
   uint64_t median = 5000;
 
-  ASSERT_TRUE(pool.fill_block_template(bl, median, textMaxCumulativeSize, 0, totalSize, txFee));
+  ASSERT_TRUE(pool.fill_block_template1(bl, median, textMaxCumulativeSize, 0, totalSize, txFee));
   ASSERT_TRUE(totalSize <= 2 * median);
 
   // check that fill_block_template prefers transactions with double fee
@@ -761,7 +761,7 @@ public:
     Block block;
     size_t totalSize;
     uint64_t totalFee;
-    ASSERT_TRUE(pool->fill_block_template(block, currency.blockGrantedFullRewardZone(), std::numeric_limits<size_t>::max(), 0, totalSize, totalFee));
+    ASSERT_TRUE(pool->fill_block_template1(block, currency.blockGrantedFullRewardZone(), std::numeric_limits<size_t>::max(), 0, totalSize, totalFee));
 
     size_t fusionTxCount = 0;
     size_t ordinaryTxCount = 0;


### PR DESCRIPTION
Hard Fork 1
We were getting blocks slower than 9 seconds because of the adaptive block size calculations. To calculate the median block size, 576,000 block timestamps were needed. This is the number of blocks produced in 60 days to prevent attacks to artificially increasing the block size due to our 0 fees. This large number of timestamps caused getting blocks templates to be delayed and block submissions to be delayed, resulting in 15 second blocks at the fastest. We decided to remove the adpative block size feature to decrease the block synchronization times. Hard fork 1 occurs at height 230,500.