### PR TITLE
Added Check Payment

### DIFF
--- a/include/IWallet.h
+++ b/include/IWallet.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
+// Copyright (c) 2018, Karbo developers
 // Copyright (c) 2018 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -8,6 +9,7 @@
 #include <limits>
 #include <string>
 #include <vector>
+#include <boost/optional.hpp>                             
 #include "CryptoNote.h"
 
 namespace CryptoNote {
@@ -59,6 +61,7 @@ struct WalletTransaction {
   uint64_t timestamp;
   uint32_t blockHeight;
   Crypto::Hash hash;
+  boost::optional<Crypto::SecretKey> secretKey;                                               
   int64_t totalAmount;
   uint64_t fee;
   uint64_t creationTime;
@@ -139,6 +142,7 @@ public:
 
   virtual size_t getTransactionCount() const = 0;
   virtual WalletTransaction getTransaction(size_t transactionIndex) const = 0;
+  virtual Crypto::SecretKey getTransactionSecretKey(size_t transactionIndex) const = 0;                                                                                     
   virtual size_t getTransactionTransferCount(size_t transactionIndex) const = 0;
   virtual WalletTransfer getTransactionTransfer(size_t transactionIndex, size_t transferIndex) const = 0;
 
@@ -148,9 +152,8 @@ public:
   virtual std::vector<Crypto::Hash> getBlockHashes(uint32_t blockIndex, size_t count) const = 0;
   virtual uint32_t getBlockCount() const  = 0;
   virtual std::vector<WalletTransactionWithTransfers> getUnconfirmedTransactions() const = 0;
-  virtual std::vector<size_t> getDelayedTransactionIds() const = 0;
-
-  virtual size_t transfer(const TransactionParameters& sendingTransaction) = 0;
+  virtual std::vector<size_t> getDelayedTransactionIds() const = 0;                                                                                                         
+  virtual size_t transfer(const TransactionParameters& sendingTransaction, Crypto::SecretKey &txSecretKey) = 0;
 
   virtual size_t makeTransaction(const TransactionParameters& sendingTransaction) = 0;
   virtual void commitTransaction(size_t transactionId) = 0;

--- a/include/IWalletLegacy.h
+++ b/include/IWalletLegacy.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
+// Copyright (c) 2018, Karbo developers
 // Copyright (c) 2018 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -10,7 +11,9 @@
 #include <ostream>
 #include <string>
 #include <system_error>
+#include <boost/optional.hpp>
 #include "CryptoNote.h"
+#include "CryptoNoteCore/CryptoNoteBasic.h"                       
 
 namespace CryptoNote {
 
@@ -43,6 +46,7 @@ struct WalletLegacyTransaction {
   uint64_t         sentTime;
   uint64_t         unlockTime;
   Crypto::Hash     hash;
+  boost::optional<Crypto::SecretKey> secretKey = CryptoNote::NULL_SECRET_KEY;                                                                           
   bool             isCoinbase;
   uint32_t         blockHeight;
   uint64_t         timestamp;
@@ -93,12 +97,15 @@ public:
   
   virtual bool getTransaction(TransactionId transactionId, WalletLegacyTransaction& transaction) = 0;
   virtual bool getTransfer(TransferId transferId, WalletLegacyTransfer& transfer) = 0;
+  virtual Crypto::SecretKey getTxKey(const Crypto::Hash& txid) = 0;                                                                                                              
 
   virtual TransactionId sendTransaction(const WalletLegacyTransfer& transfer, uint64_t fee, const std::string& extra = "", uint64_t mixIn = 0, uint64_t unlockTimestamp = 0) = 0;
   virtual TransactionId sendTransaction(const std::vector<WalletLegacyTransfer>& transfers, uint64_t fee, const std::string& extra = "", uint64_t mixIn = 0, uint64_t unlockTimestamp = 0) = 0;
   virtual std::error_code cancelTransaction(size_t transferId) = 0;
 
   virtual void getAccountKeys(AccountKeys& keys) = 0;
+
+  
 };
 
 }

--- a/src/CryptoNoteCore/CryptoNoteFormatUtils.cpp
+++ b/src/CryptoNoteCore/CryptoNoteFormatUtils.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
+// Copyright (c) 2018, Karbo developers
 // Copyright (c) 2018 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -111,6 +112,7 @@ bool constructTransaction(
   std::vector<uint8_t> extra,
   Transaction& tx,
   uint64_t unlock_time,
+  Crypto::SecretKey &tx_key,                          
   Logging::ILogger& log) {
   LoggerRef logger(log, "construct_tx");
 
@@ -124,6 +126,8 @@ bool constructTransaction(
   tx.extra = extra;
   KeyPair txkey = generateKeyPair();
   addTransactionPublicKeyToExtra(tx.extra, txkey.publicKey);
+
+  tx_key = txkey.secretKey;
 
   struct input_generation_context_data {
     KeyPair in_ephemeral;

--- a/src/CryptoNoteCore/CryptoNoteFormatUtils.h
+++ b/src/CryptoNoteCore/CryptoNoteFormatUtils.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
+// Copyright (c) 2018, Karbo developers
 // Copyright (c) 2018 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -44,7 +45,7 @@ bool constructTransaction(
   const AccountKeys& senderAccountKeys,
   const std::vector<TransactionSourceEntry>& sources,
   const std::vector<TransactionDestinationEntry>& destinations,
-  std::vector<uint8_t> extra, Transaction& transaction, uint64_t unlock_time, Logging::ILogger& log);
+  std::vector<uint8_t> extra, Transaction& transaction, uint64_t unlock_time, Crypto::SecretKey &tx_key, Logging::ILogger& log);
 
 
 bool is_out_to_acc(const AccountKeys& acc, const KeyOutput& out_key, const Crypto::PublicKey& tx_pub_key, size_t keyIndex);

--- a/src/PaymentGate/PaymentServiceJsonRpcMessages.cpp
+++ b/src/PaymentGate/PaymentServiceJsonRpcMessages.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
+// Copyright (c) 2018, Karbo developers
 // Copyright (c) 2018 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -217,6 +218,7 @@ void SendTransaction::Request::serialize(CryptoNote::ISerializer& serializer) {
 
 void SendTransaction::Response::serialize(CryptoNote::ISerializer& serializer) {
   serializer(transactionHash, "transactionHash");
+  serializer(transactionSecretKey, "transactionSecretKey");                                                         
 }
 
 void CreateDelayedTransaction::Request::serialize(CryptoNote::ISerializer& serializer) {

--- a/src/PaymentGate/PaymentServiceJsonRpcMessages.h
+++ b/src/PaymentGate/PaymentServiceJsonRpcMessages.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
+// Copyright (c) 2018, Karbo developers
 // Copyright (c) 2018 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -268,6 +269,7 @@ struct SendTransaction {
 
   struct Response {
     std::string transactionHash;
+    std::string transactionSecretKey;
 
     void serialize(CryptoNote::ISerializer& serializer);
   };

--- a/src/PaymentGate/PaymentServiceJsonRpcServer.cpp
+++ b/src/PaymentGate/PaymentServiceJsonRpcServer.cpp
@@ -1,6 +1,20 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
+// Copyright (c) 2018, Karbo developers
 // Copyright (c) 2018 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
+                                 
+  
+                                                                   
+                                                                              
+                                                                    
+                                      
+  
+                                                              
+                                                                 
+                                                                
+                                                      
+  
+                                                                           
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "PaymentServiceJsonRpcServer.h"
@@ -20,6 +34,7 @@ PaymentServiceJsonRpcServer::PaymentServiceJsonRpcServer(System::Dispatcher& sys
   , service(service)
   , logger(loggerGroup, "PaymentServiceJsonRpcServer")
 {
+                                                                                                                                                                                
   handlers.emplace("reset", jsonHandler<Reset::Request, Reset::Response>(std::bind(&PaymentServiceJsonRpcServer::handleReset, this, std::placeholders::_1, std::placeholders::_2)));
   handlers.emplace("createAddress", jsonHandler<CreateAddress::Request, CreateAddress::Response>(std::bind(&PaymentServiceJsonRpcServer::handleCreateAddress, this, std::placeholders::_1, std::placeholders::_2)));
   handlers.emplace("deleteAddress", jsonHandler<DeleteAddress::Request, DeleteAddress::Response>(std::bind(&PaymentServiceJsonRpcServer::handleDeleteAddress, this, std::placeholders::_1, std::placeholders::_2)));
@@ -38,6 +53,9 @@ PaymentServiceJsonRpcServer::PaymentServiceJsonRpcServer(System::Dispatcher& sys
   handlers.emplace("getViewKey", jsonHandler<GetViewKey::Request, GetViewKey::Response>(std::bind(&PaymentServiceJsonRpcServer::handleGetViewKey, this, std::placeholders::_1, std::placeholders::_2)));
   handlers.emplace("getStatus", jsonHandler<GetStatus::Request, GetStatus::Response>(std::bind(&PaymentServiceJsonRpcServer::handleGetStatus, this, std::placeholders::_1, std::placeholders::_2)));
   handlers.emplace("getAddresses", jsonHandler<GetAddresses::Request, GetAddresses::Response>(std::bind(&PaymentServiceJsonRpcServer::handleGetAddresses, this, std::placeholders::_1, std::placeholders::_2)));
+                                                                                                                                                                                                                                                    
+                                                                                                                                                                                                                        
+                                                                                                                                                                                                                            
 }
 
 void PaymentServiceJsonRpcServer::processJsonRpcRequest(const Common::JsonValue& req, Common::JsonValue& resp) {
@@ -78,6 +96,10 @@ void PaymentServiceJsonRpcServer::processJsonRpcRequest(const Common::JsonValue&
     makeGenericErrorReponse(resp, e.what());
   }
 }
+
+                                                                                                                         
+                                     
+ 
 
 std::error_code PaymentServiceJsonRpcServer::handleReset(const Reset::Request& request, Reset::Response& response) {
   if (request.viewSecretKey.empty()) {
@@ -142,7 +164,7 @@ std::error_code PaymentServiceJsonRpcServer::handleGetTransaction(const GetTrans
 }
 
 std::error_code PaymentServiceJsonRpcServer::handleSendTransaction(const SendTransaction::Request& request, SendTransaction::Response& response) {
-  return service.sendTransaction(request, response.transactionHash);
+  return service.sendTransaction(request, response.transactionHash, response.transactionSecretKey);
 }
 
 std::error_code PaymentServiceJsonRpcServer::handleCreateDelayedTransaction(const CreateDelayedTransaction::Request& request, CreateDelayedTransaction::Response& response) {
@@ -169,8 +191,20 @@ std::error_code PaymentServiceJsonRpcServer::handleGetStatus(const GetStatus::Re
   return service.getStatus(response.blockCount, response.knownBlockCount, response.lastBlockHash, response.peerCount);
 }
 
+                                                                                                                                                  
+                                                                                                                                       
+ 
+
 std::error_code PaymentServiceJsonRpcServer::handleGetAddresses(const GetAddresses::Request& request, GetAddresses::Response& response) {
   return service.getAddresses(response.addresses);
 }
 
+                                                                                                                                                                    
+                                                                                                                                                      
 }
+
+                                                                                                                                               
+                                                                                                                            
+ 
+
+ 

--- a/src/PaymentGate/WalletService.cpp
+++ b/src/PaymentGate/WalletService.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
-// Copyright (c) 2016-2018, The Karbowanec developers
+// Copyright (c) 2018, Karbo developers
 // Copyright (c) 2018 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -826,7 +826,7 @@ std::error_code WalletService::getAddresses(std::vector<std::string>& addresses)
   return std::error_code();
 }
 
-std::error_code WalletService::sendTransaction(const SendTransaction::Request& request, std::string& transactionHash) {
+std::error_code WalletService::sendTransaction(const SendTransaction::Request& request, std::string& transactionHash, std::string& transactionSecretKey) {
   try {
     System::EventLock lk(readyEvent);
 
@@ -852,8 +852,10 @@ std::error_code WalletService::sendTransaction(const SendTransaction::Request& r
     sendParams.unlockTimestamp = request.unlockTime;
     sendParams.changeDestination = request.changeAddress;
 
-    size_t transactionId = wallet.transfer(sendParams);
+    Crypto::SecretKey tx_key;                      
+    size_t transactionId = wallet.transfer(sendParams, tx_key);
     transactionHash = Common::podToHex(wallet.getTransaction(transactionId).hash);
+    transactionSecretKey = Common::podToHex(tx_key);                                             
 
     logger(Logging::DEBUGGING) << "Transaction " << transactionHash << " has been sent";
   } catch (std::system_error& x) {

--- a/src/PaymentGate/WalletService.h
+++ b/src/PaymentGate/WalletService.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
+// Copyright (c) 2018, Karbo developers
 // Copyright (c) 2018 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -61,7 +62,7 @@ public:
     uint32_t blockCount, const std::string& paymentId, std::vector<TransactionsInBlockRpcInfo>& transactionHashes);
   std::error_code getTransaction(const std::string& transactionHash, TransactionRpcInfo& transaction);
   std::error_code getAddresses(std::vector<std::string>& addresses);
-  std::error_code sendTransaction(const SendTransaction::Request& request, std::string& transactionHash);
+  std::error_code sendTransaction(const SendTransaction::Request& request, std::string& transactionHash, std::string& transactionSecretKey);
   std::error_code createDelayedTransaction(const CreateDelayedTransaction::Request& request, std::string& transactionHash);
   std::error_code getDelayedTransactionHashes(std::vector<std::string>& transactionHashes);
   std::error_code deleteDelayedTransaction(const std::string& transactionHash);

--- a/src/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/src/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
+// Copyright (c) 2017-2018, The Karbo developers
 // Copyright (c) 2018 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -688,6 +689,32 @@ struct COMMAND_RPC_GET_MEMPOOL {
       KV_MEMBER(status)
     }
   };
+};
+
+struct K_COMMAND_RPC_CHECK_TX_KEY {
+	struct request {
+		std::string txid;
+		std::string txkey;
+		std::string address;
+
+		void serialize(ISerializer &s) {
+			KV_MEMBER(txid)
+			KV_MEMBER(txkey)
+			KV_MEMBER(address)
+		}
+	};
+
+	struct response {
+		uint64_t amount;
+		std::vector<TransactionOutput> outputs;
+		std::string status;
+
+		void serialize(ISerializer &s) {
+			KV_MEMBER(amount)
+			KV_MEMBER(outputs)
+			KV_MEMBER(status)
+		}
+	};
 };
 
 } // end namespace CryptoNote

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -159,6 +159,7 @@ bool RpcServer::processJsonRpcRequest(const HttpRequest& request, HttpResponse& 
       { "f_block_json", { makeMemberMethod(&RpcServer::f_on_block_json), false } },
       { "f_transaction_json", { makeMemberMethod(&RpcServer::f_on_transaction_json), false } },
       { "f_mempool_json", { makeMemberMethod(&RpcServer::f_on_mempool_json), false } },
+      { "check_tx_key", { makeMemberMethod(&RpcServer::k_on_check_tx_key), false } },
     };
 
     auto it = jsonRpcHandlers.find(jsonRequest.getMethod());
@@ -927,7 +928,7 @@ bool RpcServer::f_on_transaction_json(const F_COMMAND_RPC_GET_TRANSACTION_DETAIL
   } else {
     throw JsonRpc::JsonRpcError{
       CORE_RPC_ERROR_CODE_WRONG_PARAM,
-      "transaction wasn't found. Hash = " + req.hash + '.' };
+      "Transaction ID was not found"};
   }
 
   Crypto::Hash blockHash;
@@ -1023,6 +1024,78 @@ bool RpcServer::f_on_mempool_json(const COMMAND_RPC_GET_MEMPOOL::request& req, C
 
   res.status = CORE_RPC_STATUS_OK;
   return true;
+}
+
+bool RpcServer::k_on_check_tx_key(const K_COMMAND_RPC_CHECK_TX_KEY::request& req, K_COMMAND_RPC_CHECK_TX_KEY::response& res) {
+	// parse txid
+	Crypto::Hash txid;
+	if (!parse_hash256(req.txid, txid)) {
+		throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Failed to parse txid" };
+	}
+	// parse address
+	CryptoNote::AccountPublicAddress address;
+	if (!m_core.currency().parseAccountAddressString(req.address, address)) {
+		throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Receiver's address not found" };
+	}
+	// parse txkey
+	Crypto::Hash tx_key_hash;
+	size_t size;
+	if (!Common::fromHex(req.txkey, &tx_key_hash, sizeof(tx_key_hash), size) || size != sizeof(tx_key_hash)) {
+		throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Failed to parse transaction secret key" };
+	}
+	Crypto::SecretKey tx_key = *(struct Crypto::SecretKey *) &tx_key_hash;
+
+	// fetch tx
+	Transaction tx;
+	std::vector<Crypto::Hash> tx_ids;
+	tx_ids.push_back(txid);
+	std::list<Crypto::Hash> missed_txs;
+	std::list<Transaction> txs;
+	m_core.getTransactions(tx_ids, txs, missed_txs, true);
+
+	if (1 == txs.size()) {
+		tx = txs.front();
+	}
+	else {
+		throw JsonRpc::JsonRpcError{
+			CORE_RPC_ERROR_CODE_WRONG_PARAM,
+			"Transaction ID was not found" };
+	}
+	CryptoNote::TransactionPrefix transaction = *static_cast<const TransactionPrefix*>(&tx);
+
+	// obtain key derivation
+	Crypto::KeyDerivation derivation;
+	if (!Crypto::generate_key_derivation(address.viewPublicKey, tx_key, derivation))
+	{
+		throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Failed to generate key derivation from supplied parameters" };
+	}
+	
+	// look for outputs
+	uint64_t received(0);
+	size_t keyIndex(0);
+	std::vector<TransactionOutput> outputs;
+	try {
+		for (const TransactionOutput& o : transaction.outputs) {
+			if (o.target.type() == typeid(KeyOutput)) {
+				const KeyOutput out_key = boost::get<KeyOutput>(o.target);
+				Crypto::PublicKey pubkey;
+				derive_public_key(derivation, keyIndex, address.spendPublicKey, pubkey);
+				if (pubkey == out_key.key) {
+					received += o.amount;
+					outputs.push_back(o);
+				}
+			}
+			++keyIndex;
+		}
+	}
+	catch (...)
+	{
+		throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Unknown error" };
+	}
+	res.amount = received;
+	res.outputs = outputs;
+	res.status = CORE_RPC_STATUS_OK;
+	return true;
 }
 
 } // end namespace CryptoNote

--- a/src/Rpc/RpcServer.h
+++ b/src/Rpc/RpcServer.h
@@ -77,6 +77,8 @@ private:
   bool f_getRingSize(const Transaction& transaction, uint64_t& mixin);
   bool f_on_mempool_json(const COMMAND_RPC_GET_MEMPOOL::request& req, COMMAND_RPC_GET_MEMPOOL::response& res);
 
+  bool k_on_check_tx_key(const K_COMMAND_RPC_CHECK_TX_KEY::request& req, K_COMMAND_RPC_CHECK_TX_KEY::response& res);
+
   void fill_block_header_response(const Block& blk, bool orphan_status, uint64_t height, const Crypto::Hash& hash, block_header_response& responce);
 
   Logging::LoggerRef logger;

--- a/src/SimpleWallet/SimpleWallet.h
+++ b/src/SimpleWallet/SimpleWallet.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
+// Copyright (c) 2016-2018, The Karbo developers
 // Copyright (c) 2018 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -72,10 +73,11 @@ namespace CryptoNote
     bool start_mining(const std::vector<std::string> &args);
     bool stop_mining(const std::vector<std::string> &args);
     bool show_balance(const std::vector<std::string> &args = std::vector<std::string>());
-    bool show_incoming_transfers(const std::vector<std::string> &args);
+    bool show_incoming_transactions(const std::vector<std::string> &args);
+    bool show_outgoing_transactions(const std::vector<std::string> &args);
     bool show_payments(const std::vector<std::string> &args);
     bool show_blockchain_height(const std::vector<std::string> &args);
-    bool listTransfers(const std::vector<std::string> &args);
+    bool list_transactions(const std::vector<std::string> &args);
     bool transfer(const std::vector<std::string> &args);
     bool print_address(const std::vector<std::string> &args = std::vector<std::string>());
     bool print_view_secret_key(const std::vector<std::string> &args);
@@ -83,6 +85,7 @@ namespace CryptoNote
     bool save(const std::vector<std::string> &args);
     bool reset(const std::vector<std::string> &args);
     bool set_log(const std::vector<std::string> &args);
+    bool get_tx_key(const std::vector<std::string> &args);
 
     bool ask_wallet_create_if_needed();
 

--- a/src/Wallet/WalletGreen.h
+++ b/src/Wallet/WalletGreen.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
+// Copyright (c) 2018, Karbo developers
 // Copyright (c) 2018 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -54,6 +55,7 @@ public:
 
   virtual size_t getTransactionCount() const override;
   virtual WalletTransaction getTransaction(size_t transactionIndex) const override;
+  virtual Crypto::SecretKey getTransactionSecretKey(size_t transactionIndex) const override;                                                                                          
   virtual size_t getTransactionTransferCount(size_t transactionIndex) const override;
   virtual WalletTransfer getTransactionTransfer(size_t transactionIndex, size_t transferIndex) const override;
 
@@ -65,7 +67,7 @@ public:
   virtual std::vector<WalletTransactionWithTransfers> getUnconfirmedTransactions() const override;
   virtual std::vector<size_t> getDelayedTransactionIds() const override;
 
-  virtual size_t transfer(const TransactionParameters& sendingTransaction) override;
+  virtual size_t transfer(const TransactionParameters& sendingTransaction, Crypto::SecretKey& txSecretKey) override;
 
   virtual size_t makeTransaction(const TransactionParameters& sendingTransaction) override;
   virtual void commitTransaction(size_t) override;
@@ -184,10 +186,11 @@ protected:
     uint64_t unlockTimestamp,
     const DonationSettings& donation,
     const CryptoNote::AccountPublicAddress& changeDestinationAddress,
-    PreparedTransaction& preparedTransaction);
+    PreparedTransaction& preparedTransaction,
+    Crypto::SecretKey& txSecretKey);
 
   void validateTransactionParameters(const TransactionParameters& transactionParameters);
-  size_t doTransfer(const TransactionParameters& transactionParameters);
+  size_t doTransfer(const TransactionParameters& transactionParameters, Crypto::SecretKey& txSecretKey);
 
   void requestMixinOuts(const std::vector<OutputToTransfer>& selectedTransfers,
     uint64_t mixIn,
@@ -209,13 +212,13 @@ protected:
   ReceiverAmounts splitAmount(uint64_t amount, const AccountPublicAddress& destination, uint64_t dustThreshold);
 
   std::unique_ptr<CryptoNote::ITransaction> makeTransaction(const std::vector<ReceiverAmounts>& decomposedOutputs,
-    std::vector<InputInfo>& keysInfo, const std::string& extra, uint64_t unlockTimestamp);
+    std::vector<InputInfo>& keysInfo, const std::string& extra, uint64_t unlockTimestamp, Crypto::SecretKey& txSecretKey);
 
   void sendTransaction(const CryptoNote::Transaction& cryptoNoteTransaction);
   size_t validateSaveAndSendTransaction(const ITransactionReader& transaction, const std::vector<WalletTransfer>& destinations, bool isFusion, bool send);
 
   size_t insertBlockchainTransaction(const TransactionInformation& info, int64_t txBalance);
-  size_t insertOutgoingTransactionAndPushEvent(const Crypto::Hash& transactionHash, uint64_t fee, const BinaryArray& extra, uint64_t unlockTimestamp);
+  size_t insertOutgoingTransactionAndPushEvent(const Crypto::Hash& transactionHash, uint64_t fee, const BinaryArray& extra, uint64_t unlockTimestamp, Crypto::SecretKey& txSecretKey);
   void updateTransactionStateAndPushEvent(size_t transactionId, WalletTransactionState state);
   bool updateWalletTransactionInfo(size_t transactionId, const CryptoNote::TransactionInformation& info, int64_t totalAmount);
   bool updateTransactionTransfers(size_t transactionId, const std::vector<ContainerAmounts>& containerAmountsList,

--- a/src/Wallet/WalletRpcServer.h
+++ b/src/Wallet/WalletRpcServer.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
+// Copyright (c) 2016-2018, The Karbo developers
 // Copyright (c) 2018 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -54,6 +55,7 @@ namespace Tools
     bool on_get_transfers(const wallet_rpc::COMMAND_RPC_GET_TRANSFERS::request& req, wallet_rpc::COMMAND_RPC_GET_TRANSFERS::response& res);
     bool on_get_height(const wallet_rpc::COMMAND_RPC_GET_HEIGHT::request& req, wallet_rpc::COMMAND_RPC_GET_HEIGHT::response& res);
     bool on_reset(const wallet_rpc::COMMAND_RPC_RESET::request& req, wallet_rpc::COMMAND_RPC_RESET::response& res);
+    bool on_get_tx_key(const wallet_rpc::COMMAND_RPC_GET_TX_KEY::request& req, wallet_rpc::COMMAND_RPC_GET_TX_KEY::response& res);                                 
 
     bool handle_command_line(const boost::program_options::variables_map& vm);
 

--- a/src/Wallet/WalletRpcServerCommandsDefinitions.h
+++ b/src/Wallet/WalletRpcServerCommandsDefinitions.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
+// Copyright (c) 2016-2018, Karbo developers
 // Copyright (c) 2018 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -69,9 +70,11 @@ using CryptoNote::ISerializer;
     struct response
     {
       std::string tx_hash;
+      std::string tx_key;                
 
       void serialize(ISerializer& s) {
         KV_MEMBER(tx_hash)
+        KV_MEMBER(tx_key)             
       }
     };
   };
@@ -128,6 +131,7 @@ using CryptoNote::ISerializer;
     std::string address;
     uint64_t blockIndex;
     uint64_t unlockTime;
+    std::string txKey;                     
 
     void serialize(ISerializer& s) {
       KV_MEMBER(time)
@@ -139,6 +143,7 @@ using CryptoNote::ISerializer;
       KV_MEMBER(address)
       KV_MEMBER(blockIndex)
       KV_MEMBER(unlockTime)
+      KV_MEMBER(txKey)
     }
   };
 
@@ -165,6 +170,28 @@ using CryptoNote::ISerializer;
       }
     };
   };
+
+	struct COMMAND_RPC_GET_TX_KEY
+	{
+		struct request
+		{
+			std::string tx_hash;
+
+			void serialize(ISerializer& s)
+			{
+				KV_MEMBER(tx_hash)
+			}
+		};
+		struct response
+		{
+			std::string tx_key;
+
+			void serialize(ISerializer& s)
+			{
+				KV_MEMBER(tx_key)
+			}
+		};
+	};
 
   struct COMMAND_RPC_RESET {
     typedef CryptoNote::EMPTY_STRUCT request;

--- a/src/WalletLegacy/WalletLegacy.cpp
+++ b/src/WalletLegacy/WalletLegacy.cpp
@@ -607,4 +607,15 @@ std::vector<TransactionId> WalletLegacy::deleteOutdatedUnconfirmedTransactions()
   return m_transactionsCache.deleteOutdatedTransactions();
 }
 
+Crypto::SecretKey WalletLegacy::getTxKey(const Crypto::Hash& txid) {
+  TransactionId ti = m_transactionsCache.findTransactionByHash(txid);
+  WalletLegacyTransaction transaction;
+  getTransaction(ti, transaction);
+  if (transaction.secretKey) {
+     return reinterpret_cast<const Crypto::SecretKey&>(transaction.secretKey.get());
+  } else {
+     return NULL_SECRET_KEY;
+  }
+}
+
 } //namespace CryptoNote

--- a/src/WalletLegacy/WalletLegacy.h
+++ b/src/WalletLegacy/WalletLegacy.h
@@ -66,12 +66,14 @@ public:
 
   virtual bool getTransaction(TransactionId transactionId, WalletLegacyTransaction& transaction) override;
   virtual bool getTransfer(TransferId transferId, WalletLegacyTransfer& transfer) override;
+  virtual Crypto::SecretKey getTxKey(const Crypto::Hash& txid) override;                                                                                                                   
 
   virtual TransactionId sendTransaction(const WalletLegacyTransfer& transfer, uint64_t fee, const std::string& extra = "", uint64_t mixIn = 0, uint64_t unlockTimestamp = 0) override;
   virtual TransactionId sendTransaction(const std::vector<WalletLegacyTransfer>& transfers, uint64_t fee, const std::string& extra = "", uint64_t mixIn = 0, uint64_t unlockTimestamp = 0) override;
   virtual std::error_code cancelTransaction(size_t transactionId) override;
 
   virtual void getAccountKeys(AccountKeys& keys) override;
+
 
 private:
 

--- a/src/WalletLegacy/WalletLegacySerialization.cpp
+++ b/src/WalletLegacy/WalletLegacySerialization.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
+// Copyright (c) 2018, Karbo developers
 // Copyright (c) 2018 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -6,7 +7,7 @@
 #include "WalletLegacySerialization.h"
 #include "WalletLegacy/WalletUnconfirmedTransactions.h"
 #include "IWalletLegacy.h"
-
+#include "WalletLegacy/WalletLegacySerializer.h"
 #include "CryptoNoteCore/CryptoNoteSerialization.h"
 #include "Serialization/ISerializer.h"
 #include "Serialization/SerializationOverloads.h"
@@ -23,6 +24,10 @@ void serialize(UnconfirmedTransferDetails& utd, CryptoNote::ISerializer& seriali
   uint64_t txId = static_cast<uint64_t>(utd.transactionId);
   serializer(txId, "transaction_id");
   utd.transactionId = static_cast<size_t>(txId);
+  if (CryptoNote::WALLET_LEGACY_SERIALIZATION_VERSION >= 2)
+  {
+    serializer(utd.secretKey, "secret_key");
+  }                                                         
 }
 
 void serialize(WalletLegacyTransaction& txi, CryptoNote::ISerializer& serializer) {
@@ -46,6 +51,12 @@ void serialize(WalletLegacyTransaction& txi, CryptoNote::ISerializer& serializer
   serializer(txi.unlockTime, "unlock_time");
   serializer(txi.extra, "extra");
 
+  if (CryptoNote::WALLET_LEGACY_SERIALIZATION_VERSION >= 2) {
+    Crypto::SecretKey secretKey = reinterpret_cast<const Crypto::SecretKey&>(txi.secretKey.get());
+    serializer(secretKey, "secret_key");
+    txi.secretKey = secretKey;
+  }    
+                                                       
   //this field has been added later in the structure.
   //in order to not break backward binary compatibility
   // we just set it to zero

--- a/src/WalletLegacy/WalletLegacySerializer.cpp
+++ b/src/WalletLegacy/WalletLegacySerializer.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
+// Copyright (c) 2018, Karbo developers
 // Copyright (c) 2018 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -37,14 +38,19 @@ void throwIfKeysMissmatch(const Crypto::SecretKey& sec, const Crypto::PublicKey&
 
 namespace CryptoNote {
 
+uint32_t WALLET_LEGACY_SERIALIZATION_VERSION = 2;                                                 
+
 WalletLegacySerializer::WalletLegacySerializer(CryptoNote::AccountBase& account, WalletUserTransactionsCache& transactionsCache) :
   account(account),
   transactionsCache(transactionsCache),
-  walletSerializationVersion(1)
+  walletSerializationVersion(2)
 {
 }
 
 void WalletLegacySerializer::serialize(std::ostream& stream, const std::string& password, bool saveDetailed, const std::string& cache) {
+  // set serialization version global variable
+  CryptoNote::WALLET_LEGACY_SERIALIZATION_VERSION = walletSerializationVersion;                                            
+
   std::stringstream plainArchive;
   StdOutputStream plainStream(plainArchive);
   CryptoNote::BinaryOutputStreamSerializer serializer(plainStream);
@@ -110,7 +116,9 @@ void WalletLegacySerializer::deserialize(std::istream& stream, const std::string
 
   uint32_t version;
   serializerEncrypted(version, "version");
-
+  // set serialization version global variable
+  CryptoNote::WALLET_LEGACY_SERIALIZATION_VERSION = version;
+                                            
   Crypto::chacha8_iv iv;
   serializerEncrypted(iv, "iv");
 

--- a/src/WalletLegacy/WalletLegacySerializer.h
+++ b/src/WalletLegacy/WalletLegacySerializer.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
+// Copyright (c) 2018, Karbo developers
 // Copyright (c) 2018 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -40,4 +41,6 @@ private:
   const uint32_t walletSerializationVersion;
 };
 
+extern uint32_t WALLET_LEGACY_SERIALIZATION_VERSION;
+                                                   
 } //namespace CryptoNote

--- a/src/WalletLegacy/WalletSendTransactionContext.h
+++ b/src/WalletLegacy/WalletSendTransactionContext.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
+// Copyright (c) 2018, Karbo developers
 // Copyright (c) 2018 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -32,6 +33,7 @@ struct SendTransactionContext
   std::list<TransactionOutputInformation> selectedTransfers;
   TxDustPolicy dustPolicy;
   uint64_t mixIn;
+  Crypto::SecretKey tx_key = NULL_SECRET_KEY;
 };
 
 } //namespace CryptoNote

--- a/src/WalletLegacy/WalletTransactionSender.cpp
+++ b/src/WalletLegacy/WalletTransactionSender.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
+// Copyright (c) 2018, Karbo developers
 // Copyright (c) 2018 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -44,13 +45,13 @@ void createChangeDestinations(const AccountPublicAddress& address, uint64_t need
 }
 
 void constructTx(const AccountKeys keys, const std::vector<TransactionSourceEntry>& sources, const std::vector<TransactionDestinationEntry>& splittedDests,
-    const std::string& extra, uint64_t unlockTimestamp, uint64_t sizeLimit, Transaction& tx) {
+    const std::string& extra, uint64_t unlockTimestamp, uint64_t sizeLimit, Transaction& tx, Crypto::SecretKey& tx_key) {
   std::vector<uint8_t> extraVec;
   extraVec.reserve(extra.size());
   std::for_each(extra.begin(), extra.end(), [&extraVec] (const char el) { extraVec.push_back(el);});
 
   Logging::LoggerGroup nullLog;
-  bool r = constructTransaction(keys, sources, splittedDests, extraVec, tx, unlockTimestamp, nullLog);
+  bool r = constructTransaction(keys, sources, splittedDests, extraVec, tx, unlockTimestamp, tx_key, nullLog);
 
   throwIf(!r, error::INTERNAL_WALLET_ERROR);
 
@@ -178,11 +179,11 @@ std::shared_ptr<WalletRequest> WalletTransactionSender::doSendTransaction(std::s
     splitDestinations(transaction.firstTransferId, transaction.transferCount, changeDts, context->dustPolicy, splittedDests);
 
     Transaction tx;
-    constructTx(m_keys, sources, splittedDests, transaction.extra, transaction.unlockTime, m_upperTransactionSizeLimit, tx);
+    constructTx(m_keys, sources, splittedDests, transaction.extra, transaction.unlockTime, m_upperTransactionSizeLimit, tx, context->tx_key);
 
     getObjectHash(tx, transaction.hash);
 
-    m_transactionsCache.updateTransaction(context->transactionId, tx, totalAmount, context->selectedTransfers);
+    m_transactionsCache.updateTransaction(context->transactionId, tx, totalAmount, context->selectedTransfers, context->tx_key);
 
     notifyBalanceChanged(events);
    

--- a/src/WalletLegacy/WalletTransactionSender.h
+++ b/src/WalletLegacy/WalletTransactionSender.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
+// Copyright (c) 2018, Karbo developers
 // Copyright (c) 2018 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/src/WalletLegacy/WalletUnconfirmedTransactions.cpp
+++ b/src/WalletLegacy/WalletUnconfirmedTransactions.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
+// Copyright (c) 2018, Karbo developers
 // Copyright (c) 2018 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -52,7 +53,7 @@ void WalletUnconfirmedTransactions::erase(const Hash& hash) {
 }
 
 void WalletUnconfirmedTransactions::add(const Transaction& tx, TransactionId transactionId, 
-  uint64_t amount, const std::list<TransactionOutputInformation>& usedOutputs) {
+  uint64_t amount, const std::list<TransactionOutputInformation>& usedOutputs, const Crypto::SecretKey& tx_key) {
 
   UnconfirmedTransferDetails& utd = m_unconfirmedTxs[getObjectHash(tx)];
 
@@ -60,6 +61,7 @@ void WalletUnconfirmedTransactions::add(const Transaction& tx, TransactionId tra
   utd.sentTime = time(nullptr);
   utd.tx = tx;
   utd.transactionId = transactionId;
+  utd.secretKey = tx_key;                       
 
   uint64_t outsAmount = 0;
   // process used outputs

--- a/src/WalletLegacy/WalletUnconfirmedTransactions.h
+++ b/src/WalletLegacy/WalletUnconfirmedTransactions.h
@@ -47,6 +47,7 @@ struct UnconfirmedTransferDetails {
   time_t sentTime;
   TransactionId transactionId;
   std::vector<TransactionOutputId> usedOutputs;
+  Crypto::SecretKey secretKey;                            
 };
 
 class WalletUnconfirmedTransactions
@@ -60,7 +61,7 @@ public:
   bool findTransactionId(const Crypto::Hash& hash, TransactionId& id);
   void erase(const Crypto::Hash& hash);
   void add(const CryptoNote::Transaction& tx, TransactionId transactionId, 
-    uint64_t amount, const std::list<TransactionOutputInformation>& usedOutputs);
+    uint64_t amount, const std::list<TransactionOutputInformation>& usedOutputs, const Crypto::SecretKey& tx_key);
   void updateTransactionId(const Crypto::Hash& hash, TransactionId id);
 
   uint64_t countUnconfirmedOutsAmount() const;

--- a/src/WalletLegacy/WalletUserTransactionsCache.h
+++ b/src/WalletLegacy/WalletUserTransactionsCache.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
+// Copyright (c) 2018, Karbo developers
 // Copyright (c) 2018 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -31,7 +32,7 @@ public:
   size_t getTransferCount() const;
 
   TransactionId addNewTransaction(uint64_t amount, uint64_t fee, const std::string& extra, const std::vector<WalletLegacyTransfer>& transfers, uint64_t unlockTime);
-  void updateTransaction(TransactionId transactionId, const CryptoNote::Transaction& tx, uint64_t amount, const std::list<TransactionOutputInformation>& usedOutputs);
+  void updateTransaction(TransactionId transactionId, const CryptoNote::Transaction& tx, uint64_t amount, const std::list<TransactionOutputInformation>& usedOutputs, const Crypto::SecretKey& tx_key);
   void updateTransactionSendingState(TransactionId transactionId, std::error_code ec);
 
   std::shared_ptr<WalletLegacyEvent> onTransactionUpdated(const TransactionInformation& txInfo, int64_t txBalance);
@@ -41,6 +42,7 @@ public:
 
   bool getTransaction(TransactionId transactionId, WalletLegacyTransaction& transaction) const;
   WalletLegacyTransaction& getTransaction(TransactionId transactionId);
+  TransactionId findTransactionByHash(const Crypto::Hash& hash);                                                              
   bool getTransfer(TransferId transferId, WalletLegacyTransfer& transfer) const;
   WalletLegacyTransfer& getTransfer(TransferId transferId);
 
@@ -49,9 +51,9 @@ public:
 
   std::vector<TransactionId> deleteOutdatedTransactions();
 
+
 private:
 
-  TransactionId findTransactionByHash(const Crypto::Hash& hash);
   TransactionId insertTransaction(WalletLegacyTransaction&& Transaction);
   TransferId insertTransfers(const std::vector<WalletLegacyTransfer>& transfers);
   void updateUnconfirmedTransactions();

--- a/tests/Basic/CryptoNoteFormatUtils/main.cpp
+++ b/tests/Basic/CryptoNoteFormatUtils/main.cpp
@@ -1073,7 +1073,8 @@ TEST(cryptoNoteFormatUtils, 32)
   // logger
   Logging::LoggerGroup logger;
 
-  ASSERT_TRUE(constructTransaction(senderAccountKeys, sources, destinations, extra, transaction, unlockTime, logger));
+  Crypto::SecretKey transactionSecretKeyIgnore;
+  ASSERT_TRUE(constructTransaction(senderAccountKeys, sources, destinations, extra, transaction, unlockTime, transactionSecretKeyIgnore, logger));
 
   ASSERT_EQ(transaction.version, CURRENT_TRANSACTION_VERSION);
   ASSERT_EQ(transaction.unlockTime, unlockTime);
@@ -1154,7 +1155,9 @@ TEST(cryptoNoteFormatUtils, 33)
   // logger
   Logging::LoggerGroup logger;
 
-  ASSERT_TRUE(constructTransaction(senderAccountKeys, sources, destinations, extra, transaction, unlockTime, logger));
+  Crypto::SecretKey transactionSecretKeyIgnore;
+
+  ASSERT_TRUE(constructTransaction(senderAccountKeys, sources, destinations, extra, transaction, unlockTime, transactionSecretKeyIgnore, logger));
 
   ASSERT_EQ(transaction.version, CURRENT_TRANSACTION_VERSION);
   ASSERT_EQ(transaction.unlockTime, unlockTime);

--- a/tests/Original/CoreTests/BlockValidation.cpp
+++ b/tests/Original/CoreTests/BlockValidation.cpp
@@ -339,7 +339,8 @@ bool gen_block_miner_tx_has_2_in::generate(std::vector<test_event_entry>& events
   destinations.push_back(de);
 
   Transaction tmp_tx;
-  if (!constructTransaction(miner_account.getAccountKeys(), sources, destinations, std::vector<uint8_t>(), tmp_tx, 0, m_logger))
+  Crypto::SecretKey transactionSecretKeyIgnore;
+  if (!constructTransaction(miner_account.getAccountKeys(), sources, destinations, std::vector<uint8_t>(), tmp_tx, 0, transactionSecretKeyIgnore, m_logger))
     return false;
 
   MAKE_MINER_TX_MANUALLY(miner_tx, blk_0);
@@ -382,7 +383,8 @@ bool gen_block_miner_tx_with_txin_to_key::generate(std::vector<test_event_entry>
   destinations.push_back(de);
 
   Transaction tmp_tx;
-  if (!constructTransaction(miner_account.getAccountKeys(), sources, destinations, std::vector<uint8_t>(), tmp_tx, 0, m_logger))
+  Crypto::SecretKey transactionSecretKeyIgnore;
+  if (!constructTransaction(miner_account.getAccountKeys(), sources, destinations, std::vector<uint8_t>(), tmp_tx, 0, transactionSecretKeyIgnore, m_logger))
     return false;
 
   MAKE_MINER_TX_MANUALLY(miner_tx, blk_1);

--- a/tests/Original/CoreTests/Chaingen.cpp
+++ b/tests/Original/CoreTests/Chaingen.cpp
@@ -283,7 +283,9 @@ bool construct_tx_to_key(Logging::ILogger& logger, const std::vector<test_event_
   vector<TransactionDestinationEntry> destinations;
   fill_tx_sources_and_destinations(events, blk_head, from, to, amount, fee, nmix, sources, destinations);
 
-  return constructTransaction(from.getAccountKeys(), sources, destinations, std::vector<uint8_t>(), tx, 0, logger);
+  Crypto::SecretKey transactionSecretKeyIgnore;
+
+  return constructTransaction(from.getAccountKeys(), sources, destinations, std::vector<uint8_t>(), tx, 0, transactionSecretKeyIgnore, logger);
 }
 
 Transaction construct_tx_with_fee(Logging::ILogger& logger, std::vector<test_event_entry>& events, const Block& blk_head,

--- a/tests/Original/CoreTests/IntegerOverflow.cpp
+++ b/tests/Original/CoreTests/IntegerOverflow.cpp
@@ -149,7 +149,8 @@ bool gen_uint_overflow_2::generate(std::vector<test_event_entry>& events) const
   destinations.push_back(TransactionDestinationEntry(sources.front().amount - m_currency.moneySupply() - m_currency.moneySupply() + 1 - m_currency.minimumFee(), bob_addr));
 
   CryptoNote::Transaction tx_1;
-  if (!constructTransaction(miner_account.getAccountKeys(), sources, destinations, std::vector<uint8_t>(), tx_1, 0, m_logger))
+  Crypto::SecretKey transactionSecretKeyIgnore;
+  if (!constructTransaction(miner_account.getAccountKeys(), sources, destinations, std::vector<uint8_t>(), tx_1, 0, transactionSecretKeyIgnore, m_logger))
     return false;
   events.push_back(tx_1);
 
@@ -175,7 +176,7 @@ bool gen_uint_overflow_2::generate(std::vector<test_event_entry>& events) const
   destinations.push_back(de);
 
   CryptoNote::Transaction tx_2;
-  if (!constructTransaction(bob_account.getAccountKeys(), sources, destinations, std::vector<uint8_t>(), tx_2, 0, m_logger))
+  if (!constructTransaction(bob_account.getAccountKeys(), sources, destinations, std::vector<uint8_t>(), tx_2, 0, transactionSecretKeyIgnore, m_logger))
     return false;
   events.push_back(tx_2);
 

--- a/tests/Original/CoreTests/TransactionTests.cpp
+++ b/tests/Original/CoreTests/TransactionTests.cpp
@@ -96,7 +96,8 @@ bool test_transaction_generation_and_ring_signature()
   destinations.push_back(td);
 
   Transaction tx_rc1;
-  bool r = constructTransaction(miner_acc2.getAccountKeys(), sources, destinations, std::vector<uint8_t>(), tx_rc1, 0, logger);
+  Crypto::SecretKey transactionSecretKeyIgnore;
+  bool r = constructTransaction(miner_acc2.getAccountKeys(), sources, destinations, std::vector<uint8_t>(), tx_rc1, 0, transactionSecretKeyIgnore, logger);
   CHECK_AND_ASSERT_MES(r, false, "failed to construct transaction");
 
   Crypto::Hash pref_hash = getObjectHash(*static_cast<TransactionPrefix*>(&tx_rc1));

--- a/tests/Original/CoreTests/double_spend.inl
+++ b/tests/Original/CoreTests/double_spend.inl
@@ -118,7 +118,8 @@ bool gen_double_spend_in_tx<txs_kept_by_block>::generate(std::vector<test_event_
   destinations.push_back(de);
 
   CryptoNote::Transaction tx_1;
-  if (!constructTransaction(bob_account.getAccountKeys(), sources, destinations, std::vector<uint8_t>(), tx_1, 0, this->m_logger))
+  Crypto::SecretKey transactionSecretKeyIgnore;
+  if (!constructTransaction(bob_account.getAccountKeys(), sources, destinations, std::vector<uint8_t>(), tx_1, 0, transactionSecretKeyIgnore, this->m_logger))
     return false;
 
   SET_EVENT_VISITOR_SETT(events, event_visitor_settings::set_txs_kept_by_block, txs_kept_by_block);

--- a/tests/Original/PerformanceTests/CheckRingSignature.h
+++ b/tests/Original/PerformanceTests/CheckRingSignature.h
@@ -38,7 +38,9 @@ public:
     std::vector<TransactionDestinationEntry> destinations;
     destinations.push_back(TransactionDestinationEntry(this->m_source_amount, m_alice.getAccountKeys().address));
 
-    if (!constructTransaction(this->m_miners[this->real_source_idx].getAccountKeys(), this->m_sources, destinations, std::vector<uint8_t>(), m_tx, 0, this->m_logger))
+    Crypto::SecretKey transactionSecretKeyIgnore;
+
+    if (!constructTransaction(this->m_miners[this->real_source_idx].getAccountKeys(), this->m_sources, destinations, std::vector<uint8_t>(), m_tx, 0, transactionSecretKeyIgnore, this->m_logger))
       return false;
 
     getObjectHash(*static_cast<TransactionPrefix*>(&m_tx), m_tx_prefix_hash);

--- a/tests/Original/PerformanceTests/ConstructTransaction.h
+++ b/tests/Original/PerformanceTests/ConstructTransaction.h
@@ -43,7 +43,8 @@ public:
 
   bool test()
   {
-    return CryptoNote::constructTransaction(this->m_miners[this->real_source_idx].getAccountKeys(), this->m_sources, m_destinations, std::vector<uint8_t>(), m_tx, 0, this->m_logger);
+    Crypto::SecretKey transactionSecretKeyIgnore;
+    return CryptoNote::constructTransaction(this->m_miners[this->real_source_idx].getAccountKeys(), this->m_sources, m_destinations, std::vector<uint8_t>(), m_tx, 0, transactionSecretKeyIgnore, this->m_logger);
   }
 
 private:

--- a/tests/Original/TestWallet/TestBlockchainGenerator.cpp
+++ b/tests/Original/TestWallet/TestBlockchainGenerator.cpp
@@ -35,13 +35,16 @@ public:
       [&](uint64_t chunk) { destinations.push_back(CryptoNote::TransactionDestinationEntry(chunk, address)); },
       [&](uint64_t a_dust) { destinations.push_back(CryptoNote::TransactionDestinationEntry(a_dust, address)); });
 
-    CryptoNote::constructTransaction(this->m_miners[this->real_source_idx].getAccountKeys(), this->m_sources, destinations, std::vector<uint8_t>(), tx, unlockTime, m_logger);
+    Crypto::SecretKey transactionSecretKeyIgnore;
+
+    CryptoNote::constructTransaction(this->m_miners[this->real_source_idx].getAccountKeys(), this->m_sources, destinations, std::vector<uint8_t>(), tx, unlockTime, transactionSecretKeyIgnore, m_logger);
   }
 
   void generateSingleOutputTx(const AccountPublicAddress& address, uint64_t amount, Transaction& tx) {
     std::vector<TransactionDestinationEntry> destinations;
     destinations.push_back(TransactionDestinationEntry(amount, address));
-    constructTransaction(this->m_miners[this->real_source_idx].getAccountKeys(), this->m_sources, destinations, std::vector<uint8_t>(), tx, 0, m_logger);
+    Crypto::SecretKey transactionSecretKeyIgnore;
+    constructTransaction(this->m_miners[this->real_source_idx].getAccountKeys(), this->m_sources, destinations, std::vector<uint8_t>(), tx, 0, transactionSecretKeyIgnore, m_logger);
   }
 };
 

--- a/tests/Original/TestWallet/TestWallet.cpp
+++ b/tests/Original/TestWallet/TestWallet.cpp
@@ -420,7 +420,10 @@ size_t WalletApi::sendMoneyToRandomAddressFrom(const std::string& address, uint6
   params.destinations = {order};
   params.fee = fee;
   params.changeDestination = changeDestination;
-  return alice.transfer(params);
+
+  Crypto::SecretKey txSecretKeyIgnore;
+
+  return alice.transfer(params, txSecretKeyIgnore);
 }
 
 size_t WalletApi::sendMoneyToRandomAddressFrom(const std::string& address, const std::string& changeDestination) {
@@ -457,7 +460,9 @@ size_t WalletApi::sendMoney(CryptoNote::WalletGreen& wallet, const std::string& 
   params.unlockTimestamp = unlockTimestamp;
   params.changeDestination = wallet.getAddress(0);
 
-  return wallet.transfer(params);
+  Crypto::SecretKey txSecretKeyIgnore;
+
+  return wallet.transfer(params, txSecretKeyIgnore);
 }
 
 size_t WalletApi::sendMoney(const std::string& to, uint64_t amount, uint64_t fee, uint64_t mixIn, const std::string& extra, uint64_t unlockTimestamp) {
@@ -476,7 +481,9 @@ size_t WalletApi::sendMoneyWithDonation(const std::string& to, uint64_t amount, 
   params.extra = extra;
   params.unlockTimestamp = unlockTimestamp;
 
-  return alice.transfer(params);
+  Crypto::SecretKey txSecretKeyIgnore;
+
+  return alice.transfer(params, txSecretKeyIgnore);
 }
 
 size_t WalletApi::makeTransaction(

--- a/tests/Original/TransactionPool/TransactionPool.cpp
+++ b/tests/Original/TransactionPool/TransactionPool.cpp
@@ -110,7 +110,9 @@ public:
       destinations.push_back(TransactionDestinationEntry(amountPerOut, rv_acc.getAccountKeys().address));
     }
 
-    constructTransaction(m_realSenderKeys, m_sources, destinations, std::vector<uint8_t>(), tx, 0, m_logger);
+    Crypto::SecretKey transactionSecretKeyIgnore;
+
+    constructTransaction(m_realSenderKeys, m_sources, destinations, std::vector<uint8_t>(), tx, 0, transactionSecretKeyIgnore, m_logger);
   }
 
   std::vector<AccountBase> m_miners;

--- a/tests/Original/UnitTests/TestBlockchainGenerator.cpp
+++ b/tests/Original/UnitTests/TestBlockchainGenerator.cpp
@@ -35,13 +35,16 @@ public:
       [&](uint64_t chunk) { destinations.push_back(CryptoNote::TransactionDestinationEntry(chunk, address)); },
       [&](uint64_t a_dust) { destinations.push_back(CryptoNote::TransactionDestinationEntry(a_dust, address)); });
 
-    CryptoNote::constructTransaction(this->m_miners[this->real_source_idx].getAccountKeys(), this->m_sources, destinations, std::vector<uint8_t>(), tx, unlockTime, m_logger);
+    Crypto::SecretKey transactionSecretKeyIgnore;
+
+    CryptoNote::constructTransaction(this->m_miners[this->real_source_idx].getAccountKeys(), this->m_sources, destinations, std::vector<uint8_t>(), tx, unlockTime, transactionSecretKeyIgnore, m_logger);
   }
 
   void generateSingleOutputTx(const AccountPublicAddress& address, uint64_t amount, Transaction& tx) {
     std::vector<TransactionDestinationEntry> destinations;
     destinations.push_back(TransactionDestinationEntry(amount, address));
-    constructTransaction(this->m_miners[this->real_source_idx].getAccountKeys(), this->m_sources, destinations, std::vector<uint8_t>(), tx, 0, m_logger);
+    Crypto::SecretKey transactionSecretKeyIgnore;
+    constructTransaction(this->m_miners[this->real_source_idx].getAccountKeys(), this->m_sources, destinations, std::vector<uint8_t>(), tx, 0, transactionSecretKeyIgnore, m_logger);
   }
 };
 

--- a/tests/Original/UnitTests/TransactionPool.cpp
+++ b/tests/Original/UnitTests/TransactionPool.cpp
@@ -110,7 +110,9 @@ public:
       destinations.push_back(TransactionDestinationEntry(amountPerOut, rv_acc.getAccountKeys().address));
     }
 
-    constructTransaction(m_realSenderKeys, m_sources, destinations, std::vector<uint8_t>(), tx, 0, m_logger);
+    Crypto::SecretKey transactionSecretKeyIgnore;
+
+    constructTransaction(m_realSenderKeys, m_sources, destinations, std::vector<uint8_t>(), tx, 0, transactionSecretKeyIgnore, m_logger);
   }
 
   std::vector<AccountBase> m_miners;


### PR DESCRIPTION
Check Payment

This commit adds the ability for a sender to prove that funds were sent to a recipient. The information required from the sender are the transaction id, transaction secret key, and the receiver's address. All three can be obtained by the sender using simplewallet and the command "outgoingTransactions". This feature is required by the Bisq exchange in the event that there is a dispute about funds not being received. If the sender says that he has already sent Cash2 but the receivers says that he did not receive any Cash2, the sender can prove that the money was sent by using the Cash2 block explorer to check the payment using the transaction id, transaction secret key, and the receiver's address.

The code commited here is heavily borrowed from the Karbo source code. I would like to give the biggest thanks to their development team because they have contribute imensely to the CryptoNote community. We are much in debted to you guys.