### PR TITLE
Fix Require Boost to Run Cash2 Wallet Executable Files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ else()
   if (APPLE)
 	set(WARNINGS "-Wall -Wextra -Wpointer-arith -Wundef -Wvla -Wwrite-strings")
   else()
-	set(WARNINGS "-Wall -Wextra -Wpointer-arith -Wundef -Wvla -Wwrite-strings -Werror -Wno-error=extra -Wno-error=unused-function -Wno-error=deprecated-declarations -Wno-error=sign-compare -Wno-error=strict-aliasing -Wno-error=type-limits -Wno-unused-parameter -Wno-error=unused-variable -Wno-error=undef -Wno-error=uninitialized -Wno-error=unused-result -Wno-error=implicit-fallthrough -Wno-error=logical-op -Wno-error=terminate -Wno-error=stringop-overflow -Wno-error=unused-const-variable -Wno-error=address")
+	set(WARNINGS "-Wall -Wextra -Wpointer-arith -Wundef -Wvla -Wwrite-strings -Werror -Wno-error=extra -Wno-error=unused-function -Wno-error=deprecated-declarations -Wno-error=sign-compare -Wno-error=strict-aliasing -Wno-error=type-limits -Wno-unused-parameter -Wno-error=unused-variable -Wno-error=undef -Wno-error=uninitialized -Wno-error=unused-result -Wno-error=implicit-fallthrough -Wno-error=logical-op -Wno-error=terminate -Wno-error=stringop-overflow -Wno-error=unused-const-variable -Wno-error=address -Wno-error=format-truncation")
   endif()
 
   if(CMAKE_C_COMPILER_ID STREQUAL "Clang")

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ cmake-release:
 build-release: cmake-release
 	cd build/release && $(MAKE)
 
+build-release-static:
+	mkdir -p build/release
+	cd build/release && cmake -D STATIC=ON CMAKE_BUILD_TYPE=Release ../.. && $(MAKE)
+
 test-release: build-release
 	cd build/release && $(MAKE) test
 
@@ -32,4 +36,4 @@ clean:
 tags:
 	ctags -R --sort=1 --c++-kinds=+p --fields=+iaS --extra=+q --language-force=C++ src contrib tests/gtest
 
-.PHONY: all cmake-debug build-debug test-debug all-debug cmake-release build-release test-release all-release clean tags
+.PHONY: all cmake-debug build-debug test-debug all-debug cmake-release build-release build-release-static test-release all-release clean tags


### PR DESCRIPTION
Added ability to build Cash2 code with static option so that users do not have to have Boost installed on their computers to run the wallet software.

Problem : when running ./cash2d on Ubuntu after downloading the file from the cash2.org/#downloads website, users would get the following error

./cash2d: error while loading shared libraries: libboost_system.so.1.65.1: cannot open shared object file : No such file or directory.

Compiling the source code using the static option "build-release-static" fixes this issue