### PR TITLE
Show circulating supply in "/getinfo" api for block explorer

### DIFF
--- a/src/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/src/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -267,6 +267,7 @@ struct COMMAND_RPC_GET_INFO {
     uint64_t white_peerlist_size;
     uint64_t grey_peerlist_size;
     uint32_t last_known_block_index;
+    std::string circulating_supply;
 
     void serialize(ISerializer &s) {
       KV_MEMBER(status)
@@ -280,6 +281,7 @@ struct COMMAND_RPC_GET_INFO {
       KV_MEMBER(white_peerlist_size)
       KV_MEMBER(grey_peerlist_size)
       KV_MEMBER(last_known_block_index)
+      KV_MEMBER(circulating_supply)
     }
   };
 };

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -358,6 +358,9 @@ bool RpcServer::on_get_info(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RP
   res.white_peerlist_size = m_p2p.getPeerlistManager().get_white_peers_count();
   res.grey_peerlist_size = m_p2p.getPeerlistManager().get_gray_peers_count();
   res.last_known_block_index = std::max(static_cast<uint32_t>(1), m_protocolQuery.getObservedHeight()) - 1;
+  // that large uint64_t number is unsafe in JavaScript environment and therefore as a JSON value so we display it as a formatted string
+  res.circulating_supply = m_core.currency().formatAmount(m_core.getTotalGeneratedAmount());
+
   res.status = CORE_RPC_STATUS_OK;
   return true;
 }


### PR DESCRIPTION
Show circulating supply in the block explorer api. This will be used by the CoinGeko website to show the total market cap of Cash2 and the circulating supply.