### PR TITLE
Removed code for hard fork 1

### DIFF
--- a/src/BlockchainExplorer/BlockchainExplorerDataBuilder.cpp
+++ b/src/BlockchainExplorer/BlockchainExplorerDataBuilder.cpp
@@ -135,35 +135,18 @@ bool BlockchainExplorerDataBuilder::fillBlockDetails(const Block &block, BlockDe
   int64_t emissionChange = 0;
 
   // get current blockchain height
-  
-  if (blockDetails.height < parameters::HARD_FORK_HEIGHT_1)
-  {
-    std::vector<size_t> blocksSizes;
-    if (!core.getBackwardBlocksSizes(blockDetails.height, blocksSizes, parameters::CRYPTONOTE_REWARD_BLOCKS_WINDOW)) {
-      return false;
-    }
+  // getBlockReward1 calculates the block reward based on the median block size
+  // getBlockReward2 does not calculate the block reward based on the median block size
+  // removed hard fork 1 if clause here
+  blockDetails.sizeMedian = 0;
 
-    blockDetails.sizeMedian = median(blocksSizes);
-
-    if (!core.getBlockReward1(blockDetails.sizeMedian, 0, prevBlockGeneratedCoins, 0, maxReward, emissionChange)) {
-      return false;
-    }
-    if (!core.getBlockReward1(blockDetails.sizeMedian, blockDetails.transactionsCumulativeSize, prevBlockGeneratedCoins, 0, currentReward, emissionChange)) {
-      return false;
-    }
+  if (!core.getBlockReward2(blockDetails.height, 0, prevBlockGeneratedCoins, 0, maxReward, emissionChange)) {
+    return false;
   }
-  else
-  {
-    // hard fork 1 no longer calculates the block reward based on the median block size
-    blockDetails.sizeMedian = 0;
-
-    if (!core.getBlockReward2(blockDetails.height, 0, prevBlockGeneratedCoins, 0, maxReward, emissionChange)) {
-      return false;
-    }
-    if (!core.getBlockReward2(blockDetails.height, blockDetails.transactionsCumulativeSize, prevBlockGeneratedCoins, 0, currentReward, emissionChange)) {
-      return false;
-    }
+  if (!core.getBlockReward2(blockDetails.height, blockDetails.transactionsCumulativeSize, prevBlockGeneratedCoins, 0, currentReward, emissionChange)) {
+    return false;
   }
+
 
   blockDetails.baseReward = maxReward;
   if (maxReward == 0 && currentReward == 0) {

--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -57,7 +57,10 @@ const char     P2P_NET_DATA_FILENAME[]                       = "p2pstate.bin";
 const char     CRYPTONOTE_BLOCKCHAIN_INDEXES_FILENAME[]      = "blockchainindexes.dat";
 const char     MINER_CONFIG_FILE_NAME[]                      = "miner_conf.json";
 
-const uint64_t HARD_FORK_HEIGHT_1                            = 230500;
+// HARD_FORK_HEIGHT_1 was originally set to height 230,500 but was later removed from the code because
+// all blocks prior to height 230,500 followed the new consensus rules implemented
+// Therefore, a hard fork did not really occur at 230,500
+// const uint64_t HARD_FORK_HEIGHT_1                            = 230500;
 const uint64_t HARD_FORK_HEIGHT_2                            = 420016;
 
 } // end namespace parameters

--- a/src/CryptoNoteCore/Blockchain.cpp
+++ b/src/CryptoNoteCore/Blockchain.cpp
@@ -444,12 +444,7 @@ bool Blockchain::init(const std::string& config_folder, bool load_existing) {
     }
   }
 
-  uint32_t blockchainHeight = static_cast<uint32_t>(m_blocks.size());
-
-  if (blockchainHeight < parameters::HARD_FORK_HEIGHT_1)
-  {
-    update_next_comulative_size_limit();
-  }
+  // removed hard fork 1 if clause here
 
   uint64_t timestamp_diff = time(NULL) - m_blocks.back().bl.timestamp;
   if (!m_blocks.back().bl.timestamp) {
@@ -877,24 +872,12 @@ bool Blockchain::validate_miner_transaction(const Block& b, uint32_t height, siz
     minerReward += o.amount;
   }
 
-  if (height < parameters::HARD_FORK_HEIGHT_1)
-  {
-    std::vector<size_t> lastBlocksSizes;
-    get_last_n_blocks_sizes(lastBlocksSizes, m_currency.rewardBlocksWindow());
-    size_t blocksSizeMedian = Common::medianValue(lastBlocksSizes);
+  // removed hard fork 1 if clause here
 
-    if (!m_currency.getBlockReward1(blocksSizeMedian, cumulativeBlockSize, alreadyGeneratedCoins, fee, reward, emissionChange)) {
-      logger(INFO, BRIGHT_WHITE) << "block size " << cumulativeBlockSize << " is bigger than allowed for this blockchain";
-      return false;
-    }
-  }
-  else
+  if (!m_currency.getBlockReward2(height, cumulativeBlockSize, alreadyGeneratedCoins, fee, reward, emissionChange))
   {
-    if (!m_currency.getBlockReward2(height, cumulativeBlockSize, alreadyGeneratedCoins, fee, reward, emissionChange))
-    {
-      logger(INFO, BRIGHT_WHITE) << "block size " << cumulativeBlockSize << " is bigger than allowed for this blockchain";
-      return false;
-    }
+    logger(INFO, BRIGHT_WHITE) << "block size " << cumulativeBlockSize << " is bigger than allowed for this blockchain";
+    return false;
   }
 
   if (minerReward > reward) {
@@ -1895,10 +1878,7 @@ bool Blockchain::pushBlock(const Block& blockData, const std::vector<Transaction
 
   bvc.m_added_to_main_chain = true;
 
-  if (blockchainHeight < parameters::HARD_FORK_HEIGHT_1)
-  {
-    update_next_comulative_size_limit();
-  }
+  // removed hard fork 1 if clause here
 
   return true;
 }

--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -386,94 +386,30 @@ bool core::get_block_template(Block& b, const AccountPublicAddress& adr, difficu
       }
     }
 
-    if (blockchainHeight < parameters::HARD_FORK_HEIGHT_1)
-    {
-      median_size = m_blockchain.getCurrentCumulativeBlocksizeLimit() / 2;
-    }
+    // removed hard fork 1 if clause here
     
     already_generated_coins = m_blockchain.getCoinsInCirculation();
   }
 
-  if (blockchainHeight < parameters::HARD_FORK_HEIGHT_1)
-  {
-    size_t txs_size;
-    uint64_t fee;
-    if (!m_mempool.fill_block_template1(b, median_size, m_currency.maxBlockCumulativeSize(blockchainHeight), already_generated_coins,
-      txs_size, fee)) {
-      return false;
-    }
+  // removed hard fork 1 if clause here
 
-    /*
-       two-phase miner transaction generation: we don't know exact block size until we prepare block, but we don't know reward until we know
-       block size, so first miner transaction generated with fake amount of money, and with phase we know think we know expected block size
-       */
-    //make blocks coin-base tx looks close to real coinbase tx to get truthful blob size
-    bool r = m_currency.constructMinerTx1(blockchainHeight, median_size, already_generated_coins, txs_size, fee, adr, b.baseTransaction, ex_nonce, 11);
-    if (!r) { 
-      logger(ERROR, BRIGHT_RED) << "Failed to construct miner tx, first chance"; 
-      return false; 
-    }
-
-    size_t cumulative_size = txs_size + getObjectBinarySize(b.baseTransaction);
-    for (size_t try_count = 0; try_count != 10; ++try_count) {
-      r = m_currency.constructMinerTx1(blockchainHeight, median_size, already_generated_coins, cumulative_size, fee, adr, b.baseTransaction, ex_nonce, 11);
-
-      if (!(r)) { logger(ERROR, BRIGHT_RED) << "Failed to construct miner tx, second chance"; return false; }
-      size_t coinbase_blob_size = getObjectBinarySize(b.baseTransaction);
-      if (coinbase_blob_size > cumulative_size - txs_size) {
-        cumulative_size = txs_size + coinbase_blob_size;
-        continue;
-      }
-
-      if (coinbase_blob_size < cumulative_size - txs_size) {
-        size_t delta = cumulative_size - txs_size - coinbase_blob_size;
-        b.baseTransaction.extra.insert(b.baseTransaction.extra.end(), delta, 0);
-        //here  could be 1 byte difference, because of extra field counter is varint, and it can become from 1-byte len to 2-bytes len.
-        if (cumulative_size != txs_size + getObjectBinarySize(b.baseTransaction)) {
-          if (!(cumulative_size + 1 == txs_size + getObjectBinarySize(b.baseTransaction))) { logger(ERROR, BRIGHT_RED) << "unexpected case: cumulative_size=" << cumulative_size << " + 1 is not equal txs_cumulative_size=" << txs_size << " + get_object_blobsize(b.baseTransaction)=" << getObjectBinarySize(b.baseTransaction); return false; }
-          b.baseTransaction.extra.resize(b.baseTransaction.extra.size() - 1);
-          if (cumulative_size != txs_size + getObjectBinarySize(b.baseTransaction)) {
-            //fuck, not lucky, -1 makes varint-counter size smaller, in that case we continue to grow with cumulative_size
-            logger(TRACE, BRIGHT_RED) <<
-              "Miner tx creation have no luck with delta_extra size = " << delta << " and " << delta - 1;
-            cumulative_size += delta - 1;
-            continue;
-          }
-          logger(DEBUGGING, BRIGHT_GREEN) <<
-            "Setting extra for block: " << b.baseTransaction.extra.size() << ", try_count=" << try_count;
-        }
-      }
-      if (!(cumulative_size == txs_size + getObjectBinarySize(b.baseTransaction))) { logger(ERROR, BRIGHT_RED) << "unexpected case: cumulative_size=" << cumulative_size << " is not equal txs_cumulative_size=" << txs_size << " + get_object_blobsize(b.baseTransaction)=" << getObjectBinarySize(b.baseTransaction); return false; }
-      
-      b.merkleRoot = get_tx_tree_hash(b);
-
-      return true;
-    }
-
-    logger(ERROR, BRIGHT_RED) <<
-      "Failed to create_block_template with " << 10 << " tries";
+  size_t txs_size;
+  uint64_t fee;
+  if (!m_mempool.fill_block_template2(b, m_currency.maxBlockCumulativeSize(blockchainHeight), already_generated_coins, 
+    txs_size, fee)) {
     return false;
-
   }
-  else
-  {
-    size_t txs_size;
-    uint64_t fee;
-    if (!m_mempool.fill_block_template2(b, m_currency.maxBlockCumulativeSize(blockchainHeight), already_generated_coins, 
-      txs_size, fee)) {
-      return false;
-    }
 
-    bool r = m_currency.constructMinerTx2(blockchainHeight, already_generated_coins, txs_size, fee, adr, b.baseTransaction, ex_nonce, 11);
-    if (!r) { 
-      logger(ERROR, BRIGHT_RED) << "Failed to construct miner tx"; 
-      return false; 
-    }
-
-    b.merkleRoot = get_tx_tree_hash(b);
-
-    return true;
+  bool r = m_currency.constructMinerTx2(blockchainHeight, already_generated_coins, txs_size, fee, adr, b.baseTransaction, ex_nonce, 11);
+  if (!r) { 
+    logger(ERROR, BRIGHT_RED) << "Failed to construct miner tx"; 
+    return false; 
   }
+
+  b.merkleRoot = get_tx_tree_hash(b);
+
+  return true;
+
 }
 
 std::vector<Crypto::Hash> core::findBlockchainSupplement(const std::vector<Crypto::Hash>& remoteBlockIds, size_t maxCount,

--- a/src/CryptoNoteCore/Currency.cpp
+++ b/src/CryptoNoteCore/Currency.cpp
@@ -62,7 +62,6 @@ bool Currency::init() {
   }
 
   if (isTestnet()) {
-    m_hardForkHeight1 = 0;
     m_blocksFileName = "testnet_" + m_blocksFileName;
     m_blocksCacheFileName = "testnet_" + m_blocksCacheFileName;
     m_blockIndexesFileName = "testnet_" + m_blockIndexesFileName;
@@ -677,8 +676,6 @@ CurrencyBuilder::CurrencyBuilder(Logging::ILogger& log) : m_currency(log) {
   blockIndexesFileName(parameters::CRYPTONOTE_BLOCKINDEXES_FILENAME);
   txPoolFileName(parameters::CRYPTONOTE_POOLDATA_FILENAME);
   blockchainIndexesFileName(parameters::CRYPTONOTE_BLOCKCHAIN_INDEXES_FILENAME);
-
-  hardForkHeight1(parameters::HARD_FORK_HEIGHT_1);
 
   testnet(false);
 }

--- a/src/CryptoNoteCore/Currency.h
+++ b/src/CryptoNoteCore/Currency.h
@@ -165,8 +165,6 @@ private:
   std::string m_txPoolFileName;
   std::string m_blockchainIndexesFileName;
 
-  uint64_t m_hardForkHeight1;
-
   static const std::vector<uint64_t> PRETTY_AMOUNTS;
 
   bool m_testnet;
@@ -240,8 +238,6 @@ public:
   CurrencyBuilder& txPoolFileName(const std::string& val) { m_currency.m_txPoolFileName = val; return *this; }
   CurrencyBuilder& blockchainIndexesFileName(const std::string& val) { m_currency.m_blockchainIndexesFileName = val; return *this; }
   
-  CurrencyBuilder& hardForkHeight1(uint64_t val) { m_currency.m_hardForkHeight1 = val; return *this; }
-
   CurrencyBuilder& testnet(bool val) { m_currency.m_testnet = val; return *this; }
 
 private:

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -839,31 +839,13 @@ bool RpcServer::f_on_block_json(const F_COMMAND_RPC_GET_BLOCK_DETAILS::request& 
   int64_t emissionChange = 0;
   size_t blockGrantedFullRewardZone =  CryptoNote::parameters::CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE; 
 
-  if (blockHeight < parameters::HARD_FORK_HEIGHT_1)
-  {
-    std::vector<size_t> blocksSizes;
-    if (!m_core.getBackwardBlocksSizes(res.block.height, blocksSizes, parameters::CRYPTONOTE_REWARD_BLOCKS_WINDOW)) {
-      return false;
-    }
-    res.block.sizeMedian = Common::medianValue(blocksSizes);
+  // removed hard fork 1 if clause here
 
-    res.block.effectiveSizeMedian = std::max(res.block.sizeMedian, blockGrantedFullRewardZone);
-
-    if (!m_core.getBlockReward1(res.block.sizeMedian, 0, prevBlockGeneratedCoins, 0, maxReward, emissionChange)) {
-      return false;
-    }
-    if (!m_core.getBlockReward1(res.block.sizeMedian, res.block.transactionsCumulativeSize, prevBlockGeneratedCoins, 0, currentReward, emissionChange)) {
-      return false;
-    }
+  if (!m_core.getBlockReward2(blockHeight, 0, prevBlockGeneratedCoins, 0, maxReward, emissionChange)) {
+    return false;
   }
-  else
-  {
-    if (!m_core.getBlockReward2(blockHeight, 0, prevBlockGeneratedCoins, 0, maxReward, emissionChange)) {
-      return false;
-    }
-    if (!m_core.getBlockReward2(blockHeight, res.block.transactionsCumulativeSize, prevBlockGeneratedCoins, 0, currentReward, emissionChange)) {
-      return false;
-    }
+  if (!m_core.getBlockReward2(blockHeight, res.block.transactionsCumulativeSize, prevBlockGeneratedCoins, 0, currentReward, emissionChange)) {
+    return false;
   }
 
   res.block.baseReward = maxReward;


### PR DESCRIPTION
Hardfork 1 occurred at block height 230,500. The purpose of this hardfork was to discontinue calculating the block reward based on the median block size. Instead, the block reward is calculated based on the block's size. If the block's size is less than a calculated amount, the block reward is awarded in full. However, all blocks prior to height 230,500 had block sizes that were less than this calculated amount, and therefore, there were no blocks that broke the new consensus rules.