### PR TITLE
Trying to fix remote node error "The stream is ended"

### DIFF
--- a/src/HTTP/HttpResponse.cpp
+++ b/src/HTTP/HttpResponse.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
+// Copyright (c) 2018-2019 The Karbo developers
 // Copyright (c) 2018-2019 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -44,6 +45,7 @@ namespace CryptoNote {
 HttpResponse::HttpResponse() {
   status = STATUS_200;
   headers["Server"] = "CryptoNote-based HTTP server";
+  headers["Access-Control-Allow-Origin"] = "*";
 }
 
 void HttpResponse::setStatus(HTTP_STATUS s) {

--- a/src/P2p/NetNode.cpp
+++ b/src/P2p/NetNode.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
+// Copyright (c) 2018-2019 The Karbo developers
 // Copyright (c) 2018-2019 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -1270,7 +1271,7 @@ namespace CryptoNote
   }
 
   void NodeServer::acceptLoop() {
-    for (;;) {
+    while (!m_stop) {
       try {
         P2pConnectionContext ctx(m_dispatcher, logger.getLogger(), m_listener.accept());
         ctx.m_connection_id = boost::uuids::random_generator()();


### PR DESCRIPTION
Any node that runs with the flag --rpc-bind-ip=0.0.0.0 has issues dropping connections to anyone who is connected to it. We believe this issue is caused by the failure to bind the accept loop after an exception is thrown in src/Rpc/HttpServer.cpp as pointed out by many other CryotNote projects. The solution we are using here was borrowed from the Karbo project, and we would like to give a big thanks to them.