### PR TITLE
Change mined block unlock window from 60 to 400

### DIFF
--- a/include/INode.h
+++ b/include/INode.h
@@ -70,7 +70,6 @@ public:
   virtual uint32_t getKnownBlockCount() const = 0;
   virtual uint64_t getLastLocalBlockTimestamp() const = 0;
   virtual uint64_t getMinimalFee() const = 0;
-  virtual uint64_t getDustThreshold() const = 0;
 
   virtual void relayTransaction(const Transaction& transaction, const Callback& callback) = 0;
   virtual void getRandomOutsByAmounts(std::vector<uint64_t>&& amounts, uint64_t outsCount, std::vector<CryptoNote::COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS::outs_for_amount>& result, const Callback& callback) = 0;

--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -16,8 +16,12 @@ const uint64_t DIFFICULTY_TARGET                             = 9; // seconds
 const uint64_t CRYPTONOTE_MAX_BLOCK_NUMBER                   = 500000000;
 const size_t   CRYPTONOTE_MAX_BLOCK_BLOB_SIZE                = 500000000;
 const size_t   CRYPTONOTE_MAX_TX_SIZE                        = 1000000000;
-const uint64_t CRYPTONOTE_PUBLIC_ADDRESS_BASE58_PREFIX       = 0x6; // all Cash2 addresses start with a '2' 
-const size_t   CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW          = 60;
+const uint64_t CRYPTONOTE_PUBLIC_ADDRESS_BASE58_PREFIX       = 0x6; // all Cash2 addresses start with a '2'
+
+const size_t   CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW_1        = 60;
+const size_t   CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW_2        = 400;
+const size_t   CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW          = CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW_2;
+
 const uint64_t CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT            = 60 * 60 * 2;
 const size_t   BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW             = 60;
 const uint64_t MONEY_SUPPLY                                  = UINT64_C(15000000000000000); // 15,000,000.000000000 total coins
@@ -30,13 +34,14 @@ const size_t   CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE     = 200 * 1024; //siz
 const size_t   CRYPTONOTE_COINBASE_BLOB_RESERVED_SIZE        = 600;
 const size_t   CRYPTONOTE_DISPLAY_DECIMAL_POINT              = 9; // number of digits after decimal point
 
-const uint64_t MINIMUM_FEE_1                                 = 0; // free transactions
+const uint64_t MINIMUM_FEE_1                                 = UINT64_C(0); // free transactions
 const uint64_t MINIMUM_FEE_2                                 = UINT64_C(10000000); // 0.01
 const uint64_t MINIMUM_FEE                                   = MINIMUM_FEE_2;
 
 const uint64_t DEFAULT_DUST_THRESHOLD_1                      = MINIMUM_FEE_1;
 const uint64_t DEFAULT_DUST_THRESHOLD_2                      = MINIMUM_FEE_2;
-const uint64_t DEFAULT_DUST_THRESHOLD                        = DEFAULT_DUST_THRESHOLD_2;
+const uint64_t DEFAULT_DUST_THRESHOLD_3                      = UINT64_C(0);
+const uint64_t DEFAULT_DUST_THRESHOLD                        = DEFAULT_DUST_THRESHOLD_3;
 
 const uint64_t MAX_MIXIN                                     = 3;
 const size_t   DIFFICULTY_WINDOW                             = 3600; // blocks, number of blocks expected in 9 hours
@@ -70,8 +75,15 @@ const char     MINER_CONFIG_FILE_NAME[]                      = "miner_conf.json"
 // Therefore, a hard fork did not really occur at height 230,500
 // const uint64_t HARD_FORK_HEIGHT_1                            = 230500;
 
+// HARD_FORK_HEIGHT_2 fixes integer overflow problem with calculating the next block diffiuclty using cummulative difficulties
 const uint64_t HARD_FORK_HEIGHT_2                            = 420016;
+
+// SOFT_FORK_HEIGHT_1 increases the minimum fee from 0 to 0.01 and also adds other measures to prevent blockchain spamming
 const uint64_t SOFT_FORK_HEIGHT_1                            = 1100000;
+
+// HARD_FORK_HEIGHT_3 increases the time needed to unlock a mined block from 60 blocks to 400 blocks
+// Also fixes missed default dust threshold calculations based on blockchain height in constructMinerTx1(), constructMinerTx2(), isFusionTransaction() and isAmountApplicableInFusionTransactionInput() in Currency.cpp
+const uint64_t HARD_FORK_HEIGHT_3                            = 1700000;
 
 } // end namespace parameters
 
@@ -99,8 +111,8 @@ const char     P2P_STAT_TRUSTED_PUB_KEY[]                    = "";
 
 //seed nodes
 const std::initializer_list<const char*> SEED_NODES = {
-  "seed1.cash2.org:12277",
-  "seed2.cash2.org:12279",
+  "seed1.cash2.org:12275",
+  "seed2.cash2.org:12275",
   "seed3.cash2.org:12275",
 };
 

--- a/src/CryptoNoteCore/Blockchain.cpp
+++ b/src/CryptoNoteCore/Blockchain.cpp
@@ -686,12 +686,6 @@ uint64_t Blockchain::getMinimalFee(uint32_t height)
   return m_currency.getMinimalFee(height);
 }
 
-uint64_t Blockchain::getDustThreshold()
-{
-  uint32_t blockchainHeight = getCurrentBlockchainHeight();
-  return m_currency.getDustThreshold(blockchainHeight);
-}
-
 uint64_t Blockchain::getCoinsInCirculation() {
   std::lock_guard<decltype(m_blockchain_lock)> lk(m_blockchain_lock);
   if (m_blocks.empty()) {
@@ -895,11 +889,13 @@ bool Blockchain::prevalidate_miner_transaction(const Block& b, uint32_t height) 
     return false;
   }
 
-  if (!(b.baseTransaction.unlockTime == height + m_currency.minedMoneyUnlockWindow())) {
+  size_t minedMoneyUnlockWindow = m_currency.getMinedMoneyUnlockWindow(height);
+
+  if (!(b.baseTransaction.unlockTime == height + minedMoneyUnlockWindow)) {
     logger(ERROR, BRIGHT_RED)
       << "coinbase transaction transaction have wrong unlock time="
       << b.baseTransaction.unlockTime << ", expected "
-      << height + m_currency.minedMoneyUnlockWindow();
+      << height + minedMoneyUnlockWindow;
     return false;
   }
 
@@ -1281,10 +1277,13 @@ size_t Blockchain::find_end_of_allowed_index(const std::vector<std::pair<Transac
     return 0;
   }
 
+  uint32_t blockchainHeight = getCurrentBlockchainHeight();
+  size_t minedMoneyUnlockWindow = m_currency.getMinedMoneyUnlockWindow(blockchainHeight);
+
   size_t i = amount_outs.size();
   do {
     --i;
-    if (amount_outs[i].first.block + m_currency.minedMoneyUnlockWindow() <= getCurrentBlockchainHeight()) {
+    if (amount_outs[i].first.block + minedMoneyUnlockWindow <= blockchainHeight) {
       return i + 1;
     }
   } while (i != 0);
@@ -2361,11 +2360,12 @@ bool Blockchain::loadTransactions(const Block& block, std::vector<Transaction>& 
   transactions.resize(block.transactionHashes.size());
   size_t transactionSize;
   uint64_t fee;
+  uint32_t blockchainHeight = getCurrentBlockchainHeight();
   for (size_t i = 0; i < block.transactionHashes.size(); ++i) {
     if (!m_tx_pool.take_tx(block.transactionHashes[i], transactions[i], transactionSize, fee)) {
       tx_verification_context context;
       for (size_t j = 0; j < i; ++j) {
-        if (!m_tx_pool.add_tx(transactions[i - 1 - j], context, true)) {
+        if (!m_tx_pool.add_tx(transactions[i - 1 - j], context, true, blockchainHeight)) {
           throw std::runtime_error("Blockchain::loadTransactions, failed to add transaction to pool");
         }
       }
@@ -2379,8 +2379,9 @@ bool Blockchain::loadTransactions(const Block& block, std::vector<Transaction>& 
 
 void Blockchain::saveTransactions(const std::vector<Transaction>& transactions) {
   tx_verification_context context;
+  uint32_t blockchainHeight = getCurrentBlockchainHeight();
   for (size_t i = 0; i < transactions.size(); ++i) {
-    if (!m_tx_pool.add_tx(transactions[transactions.size() - 1 - i], context, true)) {
+    if (!m_tx_pool.add_tx(transactions[transactions.size() - 1 - i], context, true, blockchainHeight)) {
       throw std::runtime_error("Blockchain::saveTransactions, failed to add transaction to pool");
     }
   }

--- a/src/CryptoNoteCore/Blockchain.h
+++ b/src/CryptoNoteCore/Blockchain.h
@@ -79,7 +79,6 @@ namespace CryptoNote {
     Crypto::Hash getTailId(uint32_t& height);
     difficulty_type getDifficultyForNextBlock();
     uint64_t getMinimalFee(uint32_t height);
-    uint64_t getDustThreshold();
     uint64_t getCoinsInCirculation();
     bool addNewBlock(const Block& bl_, block_verification_context& bvc);
     bool resetAndSetGenesisBlock(const Block& b);

--- a/src/CryptoNoteCore/Core.h
+++ b/src/CryptoNoteCore/Core.h
@@ -81,7 +81,6 @@ namespace CryptoNote {
     virtual std::error_code executeLocked(const std::function<std::error_code()>& func) override;
     virtual uint64_t getMinimalFeeForHeight(uint32_t height) override;
     virtual uint64_t getMinimalFee() override;
-    virtual uint64_t getDustThreshold() override;
     virtual uint32_t get_current_blockchain_height() override;
      
     virtual bool addMessageQueue(MessageQueue<BlockchainMessage>& messageQueue) override;

--- a/src/CryptoNoteCore/Currency.h
+++ b/src/CryptoNoteCore/Currency.h
@@ -27,6 +27,7 @@ public:
   size_t maxTxSize() const { return m_maxTxSize; }
   uint64_t publicAddressBase58Prefix() const { return m_publicAddressBase58Prefix; }
   size_t minedMoneyUnlockWindow() const { return m_minedMoneyUnlockWindow; }
+  size_t getMinedMoneyUnlockWindow(uint32_t height) const;
 
   size_t timestampCheckWindow() const { return m_timestampCheckWindow; }
   uint64_t blockFutureTimeLimit() const { return m_blockFutureTimeLimit; }
@@ -89,11 +90,11 @@ public:
 
   bool constructMinerTx2(uint32_t height, uint64_t alreadyGeneratedCoins, size_t currentBlockSize, uint64_t fee, const AccountPublicAddress& minerAddress, Transaction& tx, const BinaryArray& extraNonce, size_t maxOuts) const;
 
-  bool isFusionTransaction(const Transaction& transaction) const;
-  bool isFusionTransaction(const Transaction& transaction, size_t size) const;
-  bool isFusionTransaction(const std::vector<uint64_t>& inputsAmounts, const std::vector<uint64_t>& outputsAmounts, size_t size) const;
-  bool isAmountApplicableInFusionTransactionInput(uint64_t amount, uint64_t threshold) const;
-  bool isAmountApplicableInFusionTransactionInput(uint64_t amount, uint64_t threshold, uint8_t& amountPowerOfTen) const;
+  bool isFusionTransaction(const Transaction& transaction, uint32_t height) const;
+  bool isFusionTransaction(const Transaction& transaction, size_t size, uint32_t height) const;
+  bool isFusionTransaction(const std::vector<uint64_t>& inputsAmounts, const std::vector<uint64_t>& outputsAmounts, size_t size, uint32_t height) const;
+  bool isAmountApplicableInFusionTransactionInput(uint64_t amount, uint64_t threshold, uint32_t height) const;
+  bool isAmountApplicableInFusionTransactionInput(uint64_t amount, uint64_t threshold, uint8_t& amountPowerOfTen, uint32_t height) const;
 
   std::string accountAddressAsString(const AccountBase& account) const;
   std::string accountAddressAsString(const AccountPublicAddress& accountPublicAddress) const;

--- a/src/CryptoNoteCore/ICore.h
+++ b/src/CryptoNoteCore/ICore.h
@@ -102,7 +102,6 @@ public:
   virtual bool getTransactionsByPaymentId(const Crypto::Hash& paymentId, std::vector<Transaction>& transactions) = 0;
   virtual uint64_t getMinimalFeeForHeight(uint32_t height) = 0;
   virtual uint64_t getMinimalFee() = 0;
-  virtual uint64_t getDustThreshold() = 0;
   virtual uint32_t get_current_blockchain_height() = 0;
 
   virtual std::unique_ptr<IBlock> getBlock(const Crypto::Hash& blocksId) = 0;

--- a/src/CryptoNoteCore/TransactionPool.h
+++ b/src/CryptoNoteCore/TransactionPool.h
@@ -76,7 +76,6 @@ namespace CryptoNote {
     tx_memory_pool(
       const CryptoNote::Currency& currency, 
       CryptoNote::ITransactionValidator& validator,
-      CryptoNote::ICore& core,
       CryptoNote::ITimeProvider& timeProvider,
       Logging::ILogger& log);
 
@@ -88,8 +87,8 @@ namespace CryptoNote {
     bool deinit();
 
     bool have_tx(const Crypto::Hash &id) const;
-    bool add_tx(const Transaction &tx, const Crypto::Hash &id, size_t blobSize, tx_verification_context& tvc, bool kept_by_block);
-    bool add_tx(const Transaction &tx, tx_verification_context& tvc, bool kept_by_block);
+    bool add_tx(const Transaction &tx, const Crypto::Hash &id, size_t blobSize, tx_verification_context& tvc, bool kept_by_block, uint32_t blockchainHeight);
+    bool add_tx(const Transaction &tx, tx_verification_context& tvc, bool kept_by_block, uint32_t blockchainHeight);
     //gets tx and remove it from pool
     bool take_tx(const Crypto::Hash &id, Transaction &tx, size_t& blobSize, uint64_t& fee);
 
@@ -193,7 +192,6 @@ namespace CryptoNote {
 
     Tools::ObserverManager<ITxPoolObserver> m_observerManager;
     const CryptoNote::Currency& m_currency;
-    CryptoNote::ICore& m_core;
     OnceInTimeInterval m_txCheckInterval;
     mutable std::recursive_mutex m_transactions_lock;
     key_images_container m_spent_key_images;

--- a/src/InProcessNode/InProcessNode.cpp
+++ b/src/InProcessNode/InProcessNode.cpp
@@ -428,11 +428,6 @@ uint64_t InProcessNode::getMinimalFee() const {
   return core.getMinimalFee();
 }
 
-uint64_t InProcessNode::getDustThreshold() const {
-  std::unique_lock<std::mutex> lock(mutex);
-  return core.getDustThreshold();
-}
-
 void InProcessNode::peerCountUpdated(size_t count) {
   observerManager.notify(&INodeObserver::peerCountUpdated, count);
 }

--- a/src/InProcessNode/InProcessNode.h
+++ b/src/InProcessNode/InProcessNode.h
@@ -47,7 +47,6 @@ public:
   virtual uint32_t getKnownBlockCount() const override;
   virtual uint64_t getLastLocalBlockTimestamp() const override;
   virtual uint64_t getMinimalFee() const override;
-  virtual uint64_t getDustThreshold() const override;
 
   virtual void getNewBlocks(std::vector<Crypto::Hash>&& knownBlockIds, std::vector<CryptoNote::block_complete_entry>& newBlocks, uint32_t& startHeight, const Callback& callback) override;
   virtual void getTransactionOutsGlobalIndexes(const Crypto::Hash& transactionHash, std::vector<uint32_t>& outsGlobalIndexes, const Callback& callback) override;

--- a/src/NodeRpcProxy/NodeRpcProxy.cpp
+++ b/src/NodeRpcProxy/NodeRpcProxy.cpp
@@ -51,14 +51,14 @@ std::error_code interpretResponseStatus(const std::string& status) {
 }
 
 NodeRpcProxy::NodeRpcProxy(const std::string& nodeHost, unsigned short nodePort) :
-    m_rpcTimeout(10000),
-    m_pullInterval(5000),
-    m_nodeHost(nodeHost),
-    m_nodePort(nodePort),
-    m_lastLocalBlockTimestamp(0),
-    m_connected(true),
-    m_minimalFee(CryptoNote::parameters::MINIMUM_FEE),
-    m_dustThreshold(CryptoNote::parameters::DEFAULT_DUST_THRESHOLD) {
+  m_rpcTimeout(10000),
+  m_pullInterval(5000),
+  m_nodeHost(nodeHost),
+  m_nodePort(nodePort),
+  m_lastLocalBlockTimestamp(0),
+  m_connected(true),
+  m_minimalFee(CryptoNote::parameters::MINIMUM_FEE) {
+  
   resetInternalState();
 }
 
@@ -234,8 +234,7 @@ void NodeRpcProxy::updateBlockchainStatus() {
     }
 
     updatePeerCount(getInfoResp.incoming_connections_count + getInfoResp.outgoing_connections_count);
-    m_minimalFee.store(getInfoResp.min_tx_fee, std::memory_order_relaxed);                                                                   
-    m_dustThreshold.store(getInfoResp.dust_threshold, std::memory_order_relaxed);                                                                   
+    m_minimalFee.store(getInfoResp.min_tx_fee, std::memory_order_relaxed);
   }
 
   if (m_connected != m_httpClient->isConnected()) {
@@ -308,10 +307,6 @@ uint64_t NodeRpcProxy::getLastLocalBlockTimestamp() const {
 
 uint64_t NodeRpcProxy::getMinimalFee() const {
   return m_minimalFee.load(std::memory_order_relaxed);
-}
-
-uint64_t NodeRpcProxy::getDustThreshold() const {
-  return m_dustThreshold.load(std::memory_order_relaxed);
 }
 
 void NodeRpcProxy::relayTransaction(const CryptoNote::Transaction& transaction, const Callback& callback) {

--- a/src/NodeRpcProxy/NodeRpcProxy.h
+++ b/src/NodeRpcProxy/NodeRpcProxy.h
@@ -54,7 +54,6 @@ public:
   virtual uint32_t getKnownBlockCount() const override;
   virtual uint64_t getLastLocalBlockTimestamp() const override;
   virtual uint64_t getMinimalFee() const override;
-  virtual uint64_t getDustThreshold() const override;
 
   virtual void relayTransaction(const CryptoNote::Transaction& transaction, const Callback& callback) override;
   virtual void getRandomOutsByAmounts(std::vector<uint64_t>&& amounts, uint64_t outsCount, std::vector<COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS::outs_for_amount>& result, const Callback& callback) override;
@@ -137,7 +136,6 @@ private:
   std::atomic<uint32_t> m_nodeHeight;
   std::atomic<uint32_t> m_networkHeight;
   std::atomic<uint64_t> m_minimalFee;
-  std::atomic<uint64_t> m_dustThreshold;
 
   //protect it with mutex if decided to add worker threads
   Crypto::Hash m_lastKnowHash;

--- a/src/PaymentGate/NodeFactory.cpp
+++ b/src/PaymentGate/NodeFactory.cpp
@@ -28,7 +28,6 @@ public:
   virtual uint32_t getKnownBlockCount() const override { return 0; }
   virtual uint64_t getLastLocalBlockTimestamp() const override { return 0; }
   virtual uint64_t getMinimalFee() const override{ return 0; }
-  virtual uint64_t getDustThreshold() const override{ return 0; }
 
   virtual void relayTransaction(const CryptoNote::Transaction& transaction, const Callback& callback) override { callback(std::error_code()); }
   virtual void getRandomOutsByAmounts(std::vector<uint64_t>&& amounts, uint64_t outsCount,

--- a/tests/Original/UnitTests/ICoreStub.cpp
+++ b/tests/Original/UnitTests/ICoreStub.cpp
@@ -367,10 +367,6 @@ uint64_t ICoreStub::getMinimalFee() {
 	return 10000000ULL;
 };
 
-uint64_t ICoreStub::getDustThreshold() {
-	return 10000000ULL;
-};
-
 uint32_t ICoreStub::get_current_blockchain_height() {
   return 0;
 };

--- a/tests/Original/UnitTests/ICoreStub.h
+++ b/tests/Original/UnitTests/ICoreStub.h
@@ -84,7 +84,6 @@ public:
 
   virtual uint64_t getMinimalFeeForHeight(uint32_t height) override;
   virtual uint64_t getMinimalFee() override;
-  virtual uint64_t getDustThreshold() override;
   virtual uint32_t get_current_blockchain_height() override;
 
   void set_blockchain_top(uint32_t height, const Crypto::Hash& top_id);

--- a/tests/Original/UnitTests/INodeStubs.h
+++ b/tests/Original/UnitTests/INodeStubs.h
@@ -32,8 +32,6 @@ public:
   virtual uint32_t getKnownBlockCount() const override { return 0; };
   virtual uint64_t getLastLocalBlockTimestamp() const override { return 0; }
   virtual uint64_t getMinimalFee() const override { return 0; };
-  virtual uint64_t getDustThreshold() const override { return 0; };
-  virtual uint32_t get_current_blockchain_height() { return 0; };
 
   virtual void getNewBlocks(std::vector<Crypto::Hash>&& knownBlockIds, std::vector<CryptoNote::block_complete_entry>& newBlocks, uint32_t& height, const Callback& callback) override { callback(std::error_code()); };
 

--- a/tests/Original/UnitTests/TestCurrency.cpp
+++ b/tests/Original/UnitTests/TestCurrency.cpp
@@ -40,21 +40,24 @@ protected:
 
 TEST_F(Currency_isFusionTransactionTest, succeedsOnFusionTransaction) {
   auto tx = FusionTransactionBuilder(m_currency, TEST_AMOUNT).buildTx();
-  ASSERT_TRUE(m_currency.isFusionTransaction(tx));
+  uint32_t blockchainHeight = 0;
+  ASSERT_TRUE(m_currency.isFusionTransaction(tx, blockchainHeight));
 }
 
 TEST_F(Currency_isFusionTransactionTest, succeedsIfFusionTransactionSizeEqMaxSize) {
   FusionTransactionBuilder builder(m_currency, TEST_AMOUNT);
   auto tx = builder.createFusionTransactionBySize(m_currency.fusionTxMaxSize());
   ASSERT_EQ(m_currency.fusionTxMaxSize(), getObjectBinarySize(tx));
-  ASSERT_TRUE(m_currency.isFusionTransaction(tx));
+  uint32_t blockchainHeight = 0;
+  ASSERT_TRUE(m_currency.isFusionTransaction(tx, blockchainHeight));
 }
 
 TEST_F(Currency_isFusionTransactionTest, failsIfFusionTransactionSizeGreaterThanMaxSize) {
   FusionTransactionBuilder builder(m_currency, TEST_AMOUNT);
   auto tx = builder.createFusionTransactionBySize(m_currency.fusionTxMaxSize() + 1);
   ASSERT_EQ(m_currency.fusionTxMaxSize() + 1, getObjectBinarySize(tx));
-  ASSERT_FALSE(m_currency.isFusionTransaction(tx));
+  uint32_t blockchainHeight = 0;
+  ASSERT_FALSE(m_currency.isFusionTransaction(tx, blockchainHeight));
 }
 
 TEST_F(Currency_isFusionTransactionTest, failsIfTransactionInputsCountIsNotEnought) {
@@ -62,7 +65,8 @@ TEST_F(Currency_isFusionTransactionTest, failsIfTransactionInputsCountIsNotEnoug
   builder.setInputCount(m_currency.fusionTxMinInputCount() - 1);
   auto tx = builder.buildTx();
   ASSERT_EQ(m_currency.fusionTxMinInputCount() - 1, tx.inputs.size());
-  ASSERT_FALSE(m_currency.isFusionTransaction(tx));
+  uint32_t blockchainHeight = 0;
+  ASSERT_FALSE(m_currency.isFusionTransaction(tx, blockchainHeight));
 }
 
 TEST_F(Currency_isFusionTransactionTest, failsIfTransactionInputOutputCountRatioIsLessThenNecessary) {
@@ -70,7 +74,8 @@ TEST_F(Currency_isFusionTransactionTest, failsIfTransactionInputOutputCountRatio
   auto tx = builder.buildTx();
   ASSERT_EQ(3, tx.outputs.size());
   ASSERT_GT(tx.outputs.size() * m_currency.fusionTxMinInOutCountRatio(), tx.inputs.size());
-  ASSERT_FALSE(m_currency.isFusionTransaction(tx));
+  uint32_t blockchainHeight = 0;
+  ASSERT_FALSE(m_currency.isFusionTransaction(tx, blockchainHeight));
 }
 
 TEST_F(Currency_isFusionTransactionTest, failsIfTransactionHasNotExponentialOutput) {
@@ -78,7 +83,8 @@ TEST_F(Currency_isFusionTransactionTest, failsIfTransactionHasNotExponentialOutp
   builder.setFirstOutput(TEST_AMOUNT);
   auto tx = builder.buildTx();
   ASSERT_EQ(1, tx.outputs.size());
-  ASSERT_FALSE(m_currency.isFusionTransaction(tx));
+  uint32_t blockchainHeight = 0;
+  ASSERT_FALSE(m_currency.isFusionTransaction(tx, blockchainHeight));
 }
 
 TEST_F(Currency_isFusionTransactionTest, failsIfTransactionHasOutputsWithTheSameExponent) {
@@ -86,7 +92,8 @@ TEST_F(Currency_isFusionTransactionTest, failsIfTransactionHasOutputsWithTheSame
   builder.setFirstOutput(70 * m_currency.defaultDustThreshold());
   auto tx = builder.buildTx();
   ASSERT_EQ(2, tx.outputs.size());
-  ASSERT_FALSE(m_currency.isFusionTransaction(tx));
+  uint32_t blockchainHeight = 0;
+  ASSERT_FALSE(m_currency.isFusionTransaction(tx, blockchainHeight));
 }
 
 TEST_F(Currency_isFusionTransactionTest, succeedsIfTransactionHasDustOutput) {
@@ -94,26 +101,30 @@ TEST_F(Currency_isFusionTransactionTest, succeedsIfTransactionHasDustOutput) {
   auto tx = builder.buildTx();
   ASSERT_EQ(2, tx.outputs.size());
   ASSERT_EQ(m_currency.defaultDustThreshold(), tx.outputs[0].amount);
-  ASSERT_TRUE(m_currency.isFusionTransaction(tx));
+  uint32_t blockchainHeight = 0;
+  ASSERT_TRUE(m_currency.isFusionTransaction(tx, blockchainHeight));
 }
 
 TEST_F(Currency_isFusionTransactionTest, failsIfTransactionFeeIsNotZero) {
   FusionTransactionBuilder builder(m_currency, 370 * m_currency.defaultDustThreshold());
   builder.setFee(70 * m_currency.defaultDustThreshold());
   auto tx = builder.buildTx();
-  ASSERT_FALSE(m_currency.isFusionTransaction(tx));
+  uint32_t blockchainHeight = 0;
+  ASSERT_FALSE(m_currency.isFusionTransaction(tx, blockchainHeight));
 }
 
 TEST_F(Currency_isFusionTransactionTest, succedsIfTransactionHasInputEqualsDustThreshold) {
   FusionTransactionBuilder builder(m_currency, TEST_AMOUNT);
   builder.setFirstInput(m_currency.defaultDustThreshold());
   auto tx = builder.buildTx();
-  ASSERT_TRUE(m_currency.isFusionTransaction(tx));
+  uint32_t blockchainHeight = 0;
+  ASSERT_TRUE(m_currency.isFusionTransaction(tx, blockchainHeight));
 }
 
 TEST_F(Currency_isFusionTransactionTest, failsIfTransactionHasInputLessThanDustThreshold) {
   FusionTransactionBuilder builder(m_currency, TEST_AMOUNT);
   builder.setFirstInput(m_currency.defaultDustThreshold() - 1);
   auto tx = builder.buildTx();
-  ASSERT_FALSE(m_currency.isFusionTransaction(tx));
+  uint32_t blockchainHeight = 0;
+  ASSERT_FALSE(m_currency.isFusionTransaction(tx, blockchainHeight));
 }

--- a/tests/Original/UnitTests/TestWallet.cpp
+++ b/tests/Original/UnitTests/TestWallet.cpp
@@ -1925,7 +1925,8 @@ TEST_F(WalletApi, DISABLED_createFusionTransactionCreatesValidFusionTransactionW
 
   ASSERT_NE(WALLET_INVALID_TRANSACTION_ID, wallet.createFusionTransaction(FUSION_THRESHOLD, 0));
   ASSERT_TRUE(catchNode.caught);
-  ASSERT_TRUE(currency.isFusionTransaction(catchNode.transaction));
+  uint32_t blockchainHeight = 0;
+  ASSERT_TRUE(currency.isFusionTransaction(catchNode.transaction, blockchainHeight));
 
   wallet.shutdown();
 }
@@ -1941,7 +1942,9 @@ TEST_F(WalletApi, DISABLED_createFusionTransactionCreatesValidFusionTransactionW
 
   ASSERT_NE(WALLET_INVALID_TRANSACTION_ID, wallet.createFusionTransaction(FUSION_THRESHOLD, 2));
   ASSERT_TRUE(catchNode.caught);
-  ASSERT_TRUE(currency.isFusionTransaction(catchNode.transaction));
+
+  uint32_t blockchainHeight = 0;
+  ASSERT_TRUE(currency.isFusionTransaction(catchNode.transaction, blockchainHeight));
 
   wallet.shutdown();
 }
@@ -2054,13 +2057,16 @@ TEST_F(WalletApi, DISABLED_fusionManagerEstimate) {
   IFusionManager::EstimateResult expectedResult = {0, tx.outputs.size()};
   size_t maxOutputIndex = 0;
   uint64_t maxOutputAmount = 0;
+
+  uint32_t blockchainHeight = 0;
+
   for (size_t i = 0; i < tx.outputs.size(); ++i) {
     if (tx.outputs[i].amount > maxOutputAmount) {
       maxOutputAmount = tx.outputs[i].amount;
       maxOutputIndex = i;
     }
 
-    if (currency.isAmountApplicableInFusionTransactionInput(tx.outputs[i].amount, tx.outputs[i].amount + 1)) {
+    if (currency.isAmountApplicableInFusionTransactionInput(tx.outputs[i].amount, tx.outputs[i].amount + 1, blockchainHeight)) {
       ++expectedResult.fusionReadyCount;
     }
   }


### PR DESCRIPTION
Hardfork at block height 1,700,000 to change CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW from 60 to 400. This will require miners to wait for at least 400 blocks or about 1 hour before they can spend a coinbase transaction from a block they mined. The purpose of this change is to prepare Cash2 to be listed on exchanges. We feel that it is safer for exchanges if miners had to wait a longer period of time before they are able to deposit their funds on to an exchange due to the posibility of chain reorganizations and those funds being invalid.

Also, the dust threshold has been reduced from 10000000 to 0. This increased the number of outputs in the coinbase transaction from 3 outputs to 8 outputs.

There is also a fix made to the constructMinerTx() functions in Currency.cpp to calculate the dust threshold based on the block height, which was overlooked in the last software upgrade in version 4.2.