### PR TITLE
cryptonoteProtocolHandler: Limit number of block requests to prevent …

### DIFF
--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -108,6 +108,7 @@ const uint32_t P2P_DEFAULT_PING_CONNECTION_TIMEOUT           = 2000;          //
 const uint64_t P2P_DEFAULT_INVOKE_TIMEOUT                    = 60 * 2 * 1000; // 2 minutes
 const size_t   P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT          = 5000;          // 5 seconds
 const char     P2P_STAT_TRUSTED_PUB_KEY[]                    = "";
+const uint32_t CRYPTONOTE_PROTOCOL_MAX_OBJECT_REQUEST_COUNT  = 500;
 
 //seed nodes
 const std::initializer_list<const char*> SEED_NODES = {

--- a/src/CryptoNoteProtocol/CryptoNoteProtocolHandler.h
+++ b/src/CryptoNoteProtocol/CryptoNoteProtocolHandler.h
@@ -9,6 +9,8 @@
 
 #include <Common/ObserverManager.h>
 
+#include "../CryptoNoteConfig.h"
+
 #include "CryptoNoteCore/ICore.h"
 
 #include "CryptoNoteProtocol/CryptoNoteProtocolDefinitions.h"


### PR DESCRIPTION
…DDOS attacks

https://hackerone.com/reports/506595

A node can send such a large amount of block ID requests that core exhausts all free memory of its peer nodes. On Linux systems, when all free memory is exhausted, the program usually just crashes, which can lead to widespread network outages.