### PR TITLE
Added walletd RPC password for JSON RPC request authentication

### DIFF
--- a/src/JsonRpcServer/JsonRpcServer.cpp
+++ b/src/JsonRpcServer/JsonRpcServer.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
+// Copyright (c) 2018 The Turtlecoin developers
 // Copyright (c) 2018-2019 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -25,11 +26,12 @@
 
 namespace CryptoNote {
 
-JsonRpcServer::JsonRpcServer(System::Dispatcher& sys, System::Event& stopEvent, Logging::ILogger& loggerGroup) :
+JsonRpcServer::JsonRpcServer(System::Dispatcher& sys, System::Event& stopEvent, Logging::ILogger& loggerGroup, std::string rpcConfigurationPassword) :
   HttpServer(sys, loggerGroup), 
   system(sys),
   stopEvent(stopEvent),
-  logger(loggerGroup, "JsonRpcServer")
+  logger(loggerGroup, "JsonRpcServer"),
+  m_rpcConfigurationPassword(rpcConfigurationPassword)
 {
 }
 
@@ -152,6 +154,23 @@ void JsonRpcServer::makeMethodNotFoundResponse(Common::JsonValue& resp) {
   resp.insert("error", error);
 }
 
+void JsonRpcServer::makeIncorrectPasswordResponse(Common::JsonValue& resp) {
+  using Common::JsonValue;
+
+  JsonValue error(JsonValue::OBJECT);
+
+  JsonValue code;
+  code = static_cast<int64_t>(-32604);
+
+  JsonValue message;
+  message = "Incorrect wallet RPC password";
+
+  error.insert("code", code);
+  error.insert("message", message);
+
+  resp.insert("error", error);
+}
+
 void JsonRpcServer::fillJsonResponse(const Common::JsonValue& v, Common::JsonValue& resp) {
   resp.insert("result", v);
 }
@@ -173,6 +192,11 @@ void JsonRpcServer::makeJsonParsingErrorResponse(Common::JsonValue& resp) {
   error.insert("message", message);
 
   resp.insert("error", error);
+}
+
+std::string JsonRpcServer::getRpcConfigurationPassword()
+{
+  return m_rpcConfigurationPassword;
 }
 
 }

--- a/src/JsonRpcServer/JsonRpcServer.h
+++ b/src/JsonRpcServer/JsonRpcServer.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
+// Copyright (c) 2018 The Turtlecoin developers
 // Copyright (c) 2018-2019 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -12,6 +13,7 @@
 #include "Logging/ILogger.h"
 #include "Logging/LoggerRef.h"
 #include "Rpc/HttpServer.h"
+#include "PaymentGateService/PaymentServiceConfiguration.h"
 
 
 namespace CryptoNote {
@@ -31,7 +33,7 @@ namespace CryptoNote {
 
 class JsonRpcServer : HttpServer {
 public:
-  JsonRpcServer(System::Dispatcher& sys, System::Event& stopEvent, Logging::ILogger& loggerGroup);
+  JsonRpcServer(System::Dispatcher& sys, System::Event& stopEvent, Logging::ILogger& loggerGroup, std::string rpcPassword);
   JsonRpcServer(const JsonRpcServer&) = delete;
 
   void start(const std::string& bindAddress, uint16_t bindPort);
@@ -40,12 +42,15 @@ protected:
   static void makeErrorResponse(const std::error_code& ec, Common::JsonValue& resp);
   static void makeMethodNotFoundResponse(Common::JsonValue& resp);
   static void makeGenericErrorReponse(Common::JsonValue& resp, const char* what, int errorCode = -32001);
+  static void makeIncorrectPasswordResponse(Common::JsonValue& resp);
   static void fillJsonResponse(const Common::JsonValue& v, Common::JsonValue& resp);
   static void prepareJsonResponse(const Common::JsonValue& req, Common::JsonValue& resp);
   static void makeJsonParsingErrorResponse(Common::JsonValue& resp);
+  
+  std::string getRpcConfigurationPassword();
 
   virtual void processJsonRpcRequest(const Common::JsonValue& req, Common::JsonValue& resp) = 0;
-
+  
 private:
   // HttpServer
   virtual void processRequest(const CryptoNote::HttpRequest& request, CryptoNote::HttpResponse& response) override;
@@ -53,6 +58,7 @@ private:
   System::Dispatcher& system;
   System::Event& stopEvent;
   Logging::LoggerRef logger;
+  std::string m_rpcConfigurationPassword;
 };
 
 } //namespace CryptoNote

--- a/src/PaymentGate/PaymentServiceJsonRpcServer.h
+++ b/src/PaymentGate/PaymentServiceJsonRpcServer.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
+// Copyright (c) 2018 The Turtlecoin developers
 // Copyright (c) 2018-2019 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -19,7 +20,7 @@ class WalletService;
 
 class PaymentServiceJsonRpcServer : public CryptoNote::JsonRpcServer {
 public:
-  PaymentServiceJsonRpcServer(System::Dispatcher& sys, System::Event& stopEvent, WalletService& service, Logging::ILogger& loggerGroup);
+  PaymentServiceJsonRpcServer(System::Dispatcher& sys, System::Event& stopEvent, WalletService& service, Logging::ILogger& loggerGroup, std::string rpcConfigurationPassword);
   PaymentServiceJsonRpcServer(const PaymentServiceJsonRpcServer&) = delete;
 
 protected:

--- a/src/PaymentGateService/PaymentGateService.cpp
+++ b/src/PaymentGateService/PaymentGateService.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
+// Copyright (c) 2018 The Turtlecoin developers
 // Copyright (c) 2018-2019 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -228,7 +229,7 @@ void PaymentGateService::runWalletService(const CryptoNote::Currency& currency, 
       std::cout << "Address: " << address << std::endl;
     }
   } else {
-    PaymentService::PaymentServiceJsonRpcServer rpcServer(*dispatcher, *stopEvent, *service, logger);
+    PaymentService::PaymentServiceJsonRpcServer rpcServer(*dispatcher, *stopEvent, *service, logger, config.gateConfiguration.rpcConfigurationPassword);
     rpcServer.start(config.gateConfiguration.bindAddress, config.gateConfiguration.bindPort);
 
     try {

--- a/src/PaymentGateService/PaymentServiceConfiguration.cpp
+++ b/src/PaymentGateService/PaymentServiceConfiguration.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
+// Copyright (c) 2018 The Turtlecoin developers
 // Copyright (c) 2018-2019 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -26,12 +27,14 @@ Configuration::Configuration() {
   logLevel = Logging::INFO;
   bindAddress = "";
   bindPort = 0;
+  rpcConfigurationPassword = "";
 }
 
 void Configuration::initOptions(boost::program_options::options_description& desc) {
   desc.add_options()
       ("bind-address", po::value<std::string>()->default_value("0.0.0.0"), "payment service bind address")
       ("bind-port", po::value<uint16_t>()->default_value(8070), "payment service bind port")
+      ("rpc-password", po::value<std::string>(), "Specify a password for access to the wallet RPC server.")
       ("container-file,w", po::value<std::string>(), "container file")
       ("container-password,p", po::value<std::string>(), "container password")
       ("generate-container,g", "generate new container file with one wallet and exit")
@@ -112,6 +115,11 @@ void Configuration::init(const boost::program_options::variables_map& options) {
       throw ConfigurationError("Both container-file and container-password parameters are required");
     }
   }
+
+  if (!(options.count("rpc-password") == 0)) {
+    rpcConfigurationPassword = options["rpc-password"].as<std::string>();
+  }
+
 }
 
 } //namespace PaymentService

--- a/src/PaymentGateService/PaymentServiceConfiguration.h
+++ b/src/PaymentGateService/PaymentServiceConfiguration.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
+// Copyright (c) 2018 The Turtlecoin developers
 // Copyright (c) 2018-2019 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -26,6 +27,7 @@ struct Configuration {
 
   std::string bindAddress;
   uint16_t bindPort;
+  std::string rpcConfigurationPassword;
 
   std::string containerFile;
   std::string containerPassword;

--- a/src/Wallet/WalletErrors.h
+++ b/src/Wallet/WalletErrors.h
@@ -59,7 +59,7 @@ public:
   virtual std::string message(int ev) const override {
     switch (ev) {
     case NOT_INITIALIZED:          return "Object was not initialized";
-    case WRONG_PASSWORD:           return "The password is wrong";
+    case WRONG_PASSWORD:           return "The wallet container password is incorrect";
     case ALREADY_INITIALIZED:      return "The object is already initialized";
     case INTERNAL_WALLET_ERROR:    return "Internal error occurred";
     case MIXIN_COUNT_TOO_BIG:      return "MixIn count is too big";


### PR DESCRIPTION
Walletd JSON RPC requests did not require authentication and had the potential for an attacker to gain control of the wallet by sending JSON RPC commands to the wallet via CSRF. Users can now run the Wallet JSON RPC server with the flag --rpc-password to require that all RPC commands include a password.

Thank you to the Turtlecoin developers for their work. Much of this code is borrowed from their commit https://github.com/turtlecoin/turtlecoin/commit/4949e91e09bc1d16132090aef4dc09cc6ca09fa1

More information about this vulnerability can be found here -
https://www.cvedetails.com/cve/CVE-2018-1000093/
https://github.com/cryptonotefoundation/cryptonote/issues/172