### PR TITLE
Simplewallet RPC: Added password authentication for Simplewallet JSON…

### DIFF
--- a/src/Rpc/JsonRpc.cpp
+++ b/src/Rpc/JsonRpc.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
+// Copyright (c) 2018 The Turtlecoin developers
 // Copyright (c) 2018-2019 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -19,6 +20,7 @@ JsonRpcError::JsonRpcError(int c) : code(c) {
   case errMethodNotFound: message = "Method not found"; break;
   case errInvalidParams: message = "Invalid params"; break;
   case errInternalError: message = "Internal error"; break;
+  case errIncorrectPassword: message = "Incorrect RPC password"; break;
   default: message = "Unknown error"; break;
   }
 }

--- a/src/Rpc/JsonRpc.h
+++ b/src/Rpc/JsonRpc.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
+// Copyright (c) 2018 The Turtlecoin developers
 // Copyright (c) 2018-2019 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -25,6 +26,7 @@ const int errInvalidRequest = -32600;
 const int errMethodNotFound = -32601;
 const int errInvalidParams = -32602;
 const int errInternalError = -32603;
+const int errIncorrectPassword = -32604;
 
 class JsonRpcError: public std::exception {
 public:
@@ -50,6 +52,7 @@ public:
 };
 
 typedef boost::optional<Common::JsonValue> OptionalId;
+typedef boost::optional<Common::JsonValue> OptionalPassword;
 
 class JsonRpcRequest {
 public:
@@ -71,6 +74,11 @@ public:
 
     if (psReq.contains("id")) {
       id = psReq("id");
+    }
+
+    if (psReq.contains("password"))
+    {
+      m_password = psReq("password");
     }
 
     return true;
@@ -101,6 +109,11 @@ public:
     return id;
   }
 
+  const OptionalPassword& getPassword() const
+  {
+    return m_password;
+  }
+
   std::string getBody() {
     psReq.set("jsonrpc", std::string("2.0"));
     psReq.set("method", method);
@@ -111,6 +124,7 @@ private:
 
   Common::JsonValue psReq;
   OptionalId id;
+  OptionalPassword m_password;
   std::string method;
 };
 

--- a/src/Wallet/WalletRpcServer.h
+++ b/src/Wallet/WalletRpcServer.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2011-2016 The Cryptonote developers
 // Copyright (c) 2016-2018, The Karbo developers
+// Copyright (c) 2018 The Turtlecoin developers
 // Copyright (c) 2018-2019 The Cash2 developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -42,6 +43,7 @@ namespace Tools
 
     static const command_line::arg_descriptor<uint16_t> arg_rpc_bind_port;
     static const command_line::arg_descriptor<std::string> arg_rpc_bind_ip;
+    static const command_line::arg_descriptor<std::string> arg_rpc_password;
 
   private:
 
@@ -64,6 +66,7 @@ namespace Tools
     CryptoNote::INode& m_node;
     uint16_t m_port;
     std::string m_bind_ip;
+    std::string m_rpcConfigPassword;
     CryptoNote::Currency& m_currency;
     const std::string m_walletFilename;
 


### PR DESCRIPTION
… RPC requests

Simplewallet JSON RPC requests did not require authentication and had the potential for an attacker to gain control of the wallet by sending JSON RPC commands to the wallet via CSRF. Users can now run the Simplewallet JSON RPC server with the flag --rpc-password to require that all RPC commands include a password.

Thank you to the Turtlecoin developers for their work. Much of this code is borrowed from their commit turtlecoin/turtlecoin@4949e91

More information about this vulnerability can be found here -
https://www.cvedetails.com/cve/CVE-2018-1000093/
cryptonotefoundation#172