### PR TITLE
Daemon JSON RPC: Renamed f_transaction_json command to gettransaction

### DIFF
--- a/src/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/src/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -495,23 +495,21 @@ struct COMMAND_RPC_QUERY_BLOCKS_LITE {
 
 // Definitions for block explorer
 
-struct f_block_short_response {
+struct block_short_details_response {
   uint64_t timestamp;
   uint32_t height;
   std::string hash;
+  uint64_t size;
   uint64_t tx_count;
-  uint64_t cumul_size;
   difficulty_type difficulty;
-  uint64_t min_tx_fee;
 
   void serialize(ISerializer &s) {
     KV_MEMBER(timestamp)
     KV_MEMBER(height)
     KV_MEMBER(hash)
-    KV_MEMBER(cumul_size)
+    KV_MEMBER(size)
     KV_MEMBER(tx_count)
     KV_MEMBER(difficulty)
-	KV_MEMBER(min_tx_fee)
   }
 };
 
@@ -585,7 +583,7 @@ struct F_COMMAND_RPC_GET_BLOCKS_LIST {
   };
 
   struct response {
-    std::vector<f_block_short_response> blocks; //transactions blobs as hex
+    std::vector<block_short_details_response> blocks; //transactions blobs as hex
     std::string status;
 
     void serialize(ISerializer &s) {
@@ -633,7 +631,7 @@ struct f_transaction_details_response {
   }
 };
 
-struct F_COMMAND_RPC_GET_TRANSACTION_DETAILS {
+struct COMMAND_RPC_GET_TRANSACTION_DETAILS {
   struct request {
     std::string hash;
 
@@ -645,7 +643,7 @@ struct F_COMMAND_RPC_GET_TRANSACTION_DETAILS {
   struct response {
     Transaction tx;
     f_transaction_details_response txDetails;
-    f_block_short_response block;
+    block_short_details_response block;
     std::string status;
 
     void serialize(ISerializer &s) {

--- a/src/Rpc/RpcServer.h
+++ b/src/Rpc/RpcServer.h
@@ -73,7 +73,7 @@ private:
   // block explorer
   bool f_on_blocks_list_json(const F_COMMAND_RPC_GET_BLOCKS_LIST::request& req, F_COMMAND_RPC_GET_BLOCKS_LIST::response& res);
   bool f_on_block_json(const F_COMMAND_RPC_GET_BLOCK_DETAILS::request& req, F_COMMAND_RPC_GET_BLOCK_DETAILS::response& res);
-  bool f_on_transaction_json(const F_COMMAND_RPC_GET_TRANSACTION_DETAILS::request& req, F_COMMAND_RPC_GET_TRANSACTION_DETAILS::response& res);
+  bool on_get_transaction_json(const COMMAND_RPC_GET_TRANSACTION_DETAILS::request& req, COMMAND_RPC_GET_TRANSACTION_DETAILS::response& res);
   bool f_getRingSize(const Transaction& transaction, uint64_t& mixin);
   bool f_on_mempool_json(const COMMAND_RPC_GET_MEMPOOL::request& req, COMMAND_RPC_GET_MEMPOOL::response& res);
 


### PR DESCRIPTION
Renamed f_transaction_json command to gettransaction and also fixed the block's difficulty returned by the command.